### PR TITLE
feat: initialize ground software scaffold with CLI and CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Build artifacts
+build/
+build-*/
+
+# CMake generated files
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+compile_commands.json
+
+# Binary outputs
+*.exe
+*.obj
+*.a
+*.lib
+*.dll

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,29 @@
+#
+# @file CMakeLists.txt
+# @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+#
+
+cmake_minimum_required(VERSION 3.20)
+
+project(LBR26GroundSoftware VERSION 0.1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_library(cli
+    src/cli/args.cc
+    src/cli/config.cc
+)
+target_include_directories(cli PUBLIC include)
+
+add_library(sdr_pipeline
+    src/sdr_pipeline.cc
+)
+target_include_directories(sdr_pipeline PUBLIC include)
+target_link_libraries(sdr_pipeline PUBLIC cli)
+
+add_executable(lbr_ground
+    src/main.cc
+)
+target_link_libraries(lbr_ground PRIVATE sdr_pipeline)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
 # LBR-26-Ground-Software
+
+Ground software skeleton for the Long Beach Rocketry SDR station.
+
+## Current Scope
+
+Implemented in this version:
+- CLI argument container (`cli::Args`)
+- CLI parser/config (`cli::Config`)
+- Minimal pipeline shell (`SDRPipeline`)
+- CMake build targets (`cli`, `sdr_pipeline`, `lbr_ground`)
+
+Not implemented yet:
+- SDR device integration
+- DSP chain and decoding logic
+- Metrics and telemetry persistence
+
+## Project Structure
+
+```text
+include/
+  cli/
+    args.h
+    config.h
+  sdr_pipeline.h
+src/
+  cli/
+    args.cc
+    config.cc
+  main.cc
+  sdr_pipeline.cc
+config.demo.yaml
+CMakeLists.txt
+README.md
+```
+
+## CLI Options
+
+Implemented options:
+- `-h`, `--help`: print usage and exit successfully
+- `-c`, `--config <file>`: set config file path
+- `-v`, `--verbose`: enable verbose mode
+
+Unknown options or missing `-c` value return an error and usage text.
+
+## Run
+
+From the repo root:
+```powershell
+.\build\lbr_ground.exe --help
+.\build\lbr_ground.exe -v
+.\build\lbr_ground.exe -c .\config.yaml -v
+.\build\lbr_ground.exe -c .\config.demo.yaml -v
+```
+
+## Code Flow
+
+1. `main` wraps raw CLI input into `cli::Args`
+2. `cli::Config::parse` validates options and returns `ParseStatus`
+3. `SDRPipeline` is created with validated config
+4. `SDRPipeline::run` executes the pipeline entry routine

--- a/config.demo.yaml
+++ b/config.demo.yaml
@@ -1,0 +1,12 @@
+# Demo configuration file for LBR-26 Ground Software
+# Note: in the current codebase, this file is not parsed yet.
+
+sdr:
+  device: "rtlsdr"
+  sample_rate_hz: 2048000
+  center_freq_hz: 433920000
+  gain_db: 30
+
+pipeline:
+  verbose: true
+  output_path: "output/frame.bin"

--- a/include/cli/args.h
+++ b/include/cli/args.h
@@ -1,0 +1,47 @@
+/**
+ * @file args.h
+ * @brief Command-line arguments container
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <string_view>
+#include <vector>
+
+namespace cli {
+    class Args {
+        public:
+            /**
+             * @brief Builds an argument view container from the program entrypoint arguments.
+             * @param argc Number of arguments provided to main.
+             * @param argv Raw argument vector provided to main.
+             * @return A lightweight Args object referencing input arguments.
+             */
+            static Args from_main(int argc, char * const argv[]);
+
+            /**
+             * @brief Returns the number of stored arguments.
+             * @return Argument count available in this container.
+             */
+            std::size_t size() const noexcept;
+
+            /**
+             * @brief Returns the argument at a given index.
+             * @param index Zero-based position of the requested argument.
+             * @return Read-only view over the selected argument string.
+             */
+            std::string_view at(std::size_t index) const;
+
+            /**
+             * @brief Returns the program name (first argument) when available.
+             * @return Program name view or a fallback executable name.
+             */
+            std::string_view program_name() const noexcept;
+
+        private:
+            std::vector<std::string_view> _values;
+    };
+}

--- a/include/cli/config.h
+++ b/include/cli/config.h
@@ -1,0 +1,53 @@
+/**
+ * @file config.h
+ * @brief Command-line parsing and runtime configuration
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#pragma once
+
+#include "cli/args.h"
+
+#include <string>
+#include <string_view>
+
+namespace cli {
+    enum class ParseStatus {
+        Ok,
+        ExitSuccess,
+        ExitFailure
+    };
+
+    class Config {
+        public:
+            /**
+             * @brief Parses CLI arguments and updates runtime configuration fields.
+             * @param args Parsed argument views to process.
+             * @return Parse status indicating success, help exit, or failure.
+             */
+            ParseStatus parse(const Args &args);
+
+            /**
+             * @brief Prints command-line usage text.
+             * @param program_name Executable name to show in usage examples.
+             */
+            void usage(std::string_view program_name) const;
+
+            /**
+             * @brief Gets the configured path to the configuration file.
+             * @return Config file path string (empty if not provided).
+             */
+            const std::string &config_file() const noexcept;
+
+            /**
+             * @brief Indicates whether verbose mode is enabled.
+             * @return True when verbose logging is enabled.
+             */
+            bool verbose() const noexcept;
+
+        private:
+            std::string _config_file;
+            bool _verbose = false;
+    };
+}

--- a/include/sdr_pipeline.h
+++ b/include/sdr_pipeline.h
@@ -1,0 +1,27 @@
+/**
+ * @file sdr_pipeline.h
+ * @brief Minimal SDR pipeline interface
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#pragma once
+
+#include "cli/config.h"
+
+class SDRPipeline {
+    public:
+        /**
+         * @brief Creates the SDR pipeline instance from validated runtime config.
+         * @param config Application configuration produced by CLI parsing.
+         */
+        explicit SDRPipeline(const cli::Config &config);
+
+        /**
+         * @brief Starts the SDR processing workflow.
+         */
+        void run();
+
+    private:
+        cli::Config _config;
+};

--- a/src/cli/args.cc
+++ b/src/cli/args.cc
@@ -1,0 +1,38 @@
+/**
+ * @file args.cc
+ * @brief Command-line arguments container implementation
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#include "cli/args.h"
+
+#include <stdexcept>
+
+cli::Args cli::Args::from_main(int argc, char * const argv[]) {
+    Args args;
+
+    args._values.reserve(static_cast<std::size_t>(argc));
+    for (int i = 0; i < argc; ++i)
+        args._values.emplace_back(argv[i] == nullptr ? "" : argv[i]);
+
+    return args;
+}
+
+std::size_t cli::Args::size() const noexcept {
+    return _values.size();
+}
+
+std::string_view cli::Args::at(std::size_t index) const {
+    if (index >= _values.size())
+        throw std::out_of_range("Argument index out of range");
+
+    return _values[index];
+}
+
+std::string_view cli::Args::program_name() const noexcept {
+    if (_values.empty())
+        return "lbr-ground";
+
+    return _values.front();
+}

--- a/src/cli/config.cc
+++ b/src/cli/config.cc
@@ -1,0 +1,59 @@
+/**
+ * @file config.cc
+ * @brief Command-line parsing and runtime configuration implementation
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#include "cli/config.h"
+
+#include <iostream>
+
+cli::ParseStatus cli::Config::parse(const Args &args) {
+    for (std::size_t i = 1; i < args.size(); ++i) {
+        const auto arg = args.at(i);
+
+        if (arg == "-h" || arg == "--help") {
+            usage(args.program_name());
+            return ParseStatus::ExitSuccess;
+        }
+
+        if (arg == "-v" || arg == "--verbose") {
+            _verbose = true;
+            continue;
+        }
+
+        if (arg == "-c" || arg == "--config") {
+            if (i + 1 >= args.size()) {
+                std::cerr << "Missing value for option: " << arg << '\n';
+                usage(args.program_name());
+                return ParseStatus::ExitFailure;
+            }
+
+            _config_file = std::string(args.at(++i));
+            continue;
+        }
+
+        std::cerr << "Unknown option: " << arg << '\n';
+        usage(args.program_name());
+        return ParseStatus::ExitFailure;
+    }
+
+    return ParseStatus::Ok;
+}
+
+void cli::Config::usage(std::string_view program_name) const {
+    std::cout << "Usage: " << program_name << " [options]\n"
+              << "Options:\n"
+              << "  -h, --help            Show this help message and exit\n"
+              << "  -c, --config <file>   Path to configuration file\n"
+              << "  -v, --verbose         Enable verbose output" << std::endl;
+}
+
+const std::string &cli::Config::config_file() const noexcept {
+    return _config_file;
+}
+
+bool cli::Config::verbose() const noexcept {
+    return _verbose;
+}

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,0 +1,62 @@
+/**
+ * @file main.cc
+ * @brief Entry point for SDR RF-to-Binary pipeline
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ *
+ * Project: Long Beach Rocketry - Ground Station SDR
+ *
+ * Description:
+ *   Initializes the RF-to-binary processing pipeline.
+ *   Sets up IQ source, processing threads, and metrics.
+ *   Responsible for clean startup and shutdown.
+ *
+ * Notes:
+ *   - No DSP logic should be implemented directly in this file.
+ *   - All processing must be delegated to modules.
+*/
+
+#include "cli/config.h"
+#include "sdr_pipeline.h"
+
+#include <exception>
+#include <iostream>
+
+/**
+ * @brief Main entry point for the SDR RF-to-binary processing pipeline
+ *
+ * @param argc Number of command-line arguments
+ * @param argv Array of command-line argument strings
+ *
+ * @return Exit status code (0 for success, non-zero for errors)
+ *
+ * This function initializes the configuration by parsing command-line arguments,
+ * sets up the SDR processing pipeline, and starts the processing loop.
+ * It ensures that all resources are properly released on shutdown.
+ */
+int main(int argc, char * const argv[]) {
+    cli::Config config;
+
+    const cli::Args args = cli::Args::from_main(argc, argv);
+
+    switch (config.parse(args)) {
+        case cli::ParseStatus::ExitSuccess:
+            return 0;
+        case cli::ParseStatus::ExitFailure:
+            return 1;
+    default:
+        config.usage(args.program_name());
+        break;
+    }
+
+    SDRPipeline pipeline(config);
+
+    try {
+        pipeline.run();
+    } catch (const std::exception &e) {
+        std::cerr << "Error: " << e.what() << std::endl;
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/sdr_pipeline.cc
+++ b/src/sdr_pipeline.cc
@@ -1,0 +1,22 @@
+/**
+ * @file sdr_pipeline.cc
+ * @brief Minimal SDR pipeline implementation
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#include "sdr_pipeline.h"
+
+#include <iostream>
+
+SDRPipeline::SDRPipeline(const cli::Config &config) : _config(config) {}
+
+void SDRPipeline::run() {
+    if (_config.verbose()) {
+        std::cout << "Starting SDR pipeline";
+        if (!_config.config_file().empty())
+            std::cout << " with config: " << _config.config_file();
+
+        std::cout << '\n';
+    }
+}


### PR DESCRIPTION
Summary
> Initialize C++ project scaffold with CMake targets (cli, sdr_pipeline, lbr_ground)
> Implement CLI argument parsing and configuration modules
> Add minimal SDR pipeline skeleton (initial structure only)
> Add project documentation and example configuration file
> Add .gitignore and ensure clean build artifacts

Notes
> The -c / --config option currently stores the configuration file path but does not yet parse its contents
> Project builds successfully using MSYS2 UCRT64 with Ninja