### PR TITLE
docs: add project documentation and streamline root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,31 @@
 # LBR-26-Ground-Software
 
-Ground software skeleton for the Long Beach Rocketry SDR station.
+Ground software scaffold for the Long Beach Rocketry SDR station.
 
-## Current Scope
+## Documentation
 
-Implemented in this version:
-- CLI argument container (`cli::Args`)
-- CLI parser/config (`cli::Config`)
-- Minimal pipeline shell (`SDRPipeline`)
-- CMake build targets (`cli`, `sdr_pipeline`, `lbr_ground`)
+- Overview: `docs/README.md`
+- Build and run: `docs/build-and-run.md`
+- Configuration format: `docs/configuration.md`
+- Architecture: `docs/architecture.md`
+- Tests and coverage: `docs/build-and-run.md`
 
-Not implemented yet:
-- SDR device integration
-- DSP chain and decoding logic
-- Metrics and telemetry persistence
+## CI/CD
 
-## Project Structure
+GitHub Actions workflow:
+- `.github/workflows/ci.yml`
 
-```text
-include/
-  cli/
-    args.h
-    config.h
-  sdr_pipeline.h
-src/
-  cli/
-    args.cc
-    config.cc
-  main.cc
-  sdr_pipeline.cc
-config.demo.yaml
-CMakeLists.txt
-README.md
-```
+It runs:
+- build + tests (`ctest`) on pushes and pull requests
+- coverage generation (`gcovr`) with artifacts:
+  - `coverage.xml`
+  - `coverage.html`
 
-## CLI Options
+## Quick Start
 
-Implemented options:
-- `-h`, `--help`: print usage and exit successfully
-- `-c`, `--config <file>`: set config file path
-- `-v`, `--verbose`: enable verbose mode
-
-Unknown options or missing `-c` value return an error and usage text.
-
-## Run
-
-From the repo root:
 ```powershell
-.\build\lbr_ground.exe --help
-.\build\lbr_ground.exe -v
-.\build\lbr_ground.exe -c .\config.yaml -v
+$env:PATH = "C:\msys64\ucrt64\bin;C:\msys64\usr\bin;$env:PATH"
+cmake -S . -B build -G Ninja -DCMAKE_MAKE_PROGRAM=C:\msys64\ucrt64\bin\ninja.exe -DCMAKE_CXX_COMPILER=C:\msys64\ucrt64\bin\g++.exe -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j
 .\build\lbr_ground.exe -c .\config.demo.yaml -v
 ```
-
-## Code Flow
-
-1. `main` wraps raw CLI input into `cli::Args`
-2. `cli::Config::parse` validates options and returns `ParseStatus`
-3. `SDRPipeline` is created with validated config
-4. `SDRPipeline::run` executes the pipeline entry routine

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Documentation
+
+This folder contains the project documentation for `LBR-26-Ground-Software`.
+
+## Contents
+
+- `docs/build-and-run.md`: build prerequisites and run commands
+- `docs/configuration.md`: YAML configuration format and validation rules
+- `docs/architecture.md`: code structure and runtime flow
+- test and coverage flow is documented in `docs/build-and-run.md`
+
+## Quick Start
+
+1. Build the project (see `docs/build-and-run.md`)
+2. Use `config.demo.yaml` or your own config (see `docs/configuration.md`)
+3. Run the executable and validate logs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,36 @@
+# Architecture
+
+## Modules
+
+- `cli::Args` (`include/cli/args.h`, `src/cli/args.cc`)
+  - Wraps `argc/argv` as safe argument views.
+- `cli::Config` (`include/cli/config.h`, `src/cli/config.cc`)
+  - Parses CLI flags.
+  - Loads and validates YAML config.
+  - Produces `RuntimeSettings`.
+- `SDRPipeline` (`include/sdr_pipeline.h`, `src/sdr_pipeline.cc`)
+  - Receives validated `RuntimeSettings`.
+  - Executes pipeline entry routine (currently minimal logging behavior).
+- `main` (`src/main.cc`)
+  - Orchestrates startup, parse flow, and pipeline execution.
+- test suites (`tests/*.cc`)
+  - GoogleTest-based unit suites:
+    - `ArgsTests` (`tests/args_tests.cc`)
+    - `ConfigTests` (`tests/config_tests.cc`)
+    - `PipelineTests` (`tests/pipeline_tests.cc`)
+
+## Runtime Flow
+
+1. `main` builds `cli::Args` from `argc/argv`.
+2. `cli::Config::parse` handles:
+   - `-h/--help`
+   - `-c/--config <file>`
+   - `-v/--verbose`
+3. When `-c` is used, YAML is parsed and validated.
+4. `SDRPipeline` is constructed with `config.settings()`.
+5. `SDRPipeline::run` executes.
+
+## Current Status
+
+- Config and startup flow are implemented.
+- SDR hardware and DSP stages are not implemented yet.

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -1,0 +1,57 @@
+# Build and Run
+
+## Prerequisites
+
+- CMake
+- MSYS2 UCRT64 toolchain
+- `g++` (`C:\msys64\ucrt64\bin\g++.exe`)
+- `ninja` (`C:\msys64\ucrt64\bin\ninja.exe`)
+
+Note: `yaml-cpp` is fetched automatically by CMake (`FetchContent`).
+GoogleTest is also fetched automatically when `BUILD_TESTING=ON` (default).
+
+## Build (PowerShell)
+
+```powershell
+$env:PATH = "C:\msys64\ucrt64\bin;C:\msys64\usr\bin;$env:PATH"
+cmake -S . -B build -G Ninja -DCMAKE_MAKE_PROGRAM=C:\msys64\ucrt64\bin\ninja.exe -DCMAKE_CXX_COMPILER=C:\msys64\ucrt64\bin\g++.exe -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j
+```
+
+## Test
+
+```powershell
+ctest --test-dir build --output-on-failure
+```
+
+This runs:
+- unit test binary (`lbr_tests`, based on GoogleTest)
+- integration checks on `lbr_ground` (`--help`, demo config, missing config failure path)
+
+## Coverage
+
+Build with coverage instrumentation:
+
+```powershell
+$env:PATH = "C:\msys64\ucrt64\bin;C:\msys64\usr\bin;$env:PATH"
+cmake -S . -B build-coverage -G Ninja -DCMAKE_MAKE_PROGRAM=C:\msys64\ucrt64\bin\ninja.exe -DCMAKE_CXX_COMPILER=C:\msys64\ucrt64\bin\g++.exe -DCMAKE_BUILD_TYPE=Debug -DLBR_ENABLE_COVERAGE=ON
+cmake --build build-coverage -j
+cmake --build build-coverage --target coverage
+```
+
+Coverage artifacts are generated in:
+- `build-coverage/coverage/*.gcov`
+
+## Run
+
+```powershell
+.\build\lbr_ground.exe --help
+.\build\lbr_ground.exe -c .\config.demo.yaml
+.\build\lbr_ground.exe -c .\config.demo.yaml -v
+```
+
+## Expected Behavior
+
+- `--help` prints usage and exits with success.
+- `-c <file>` loads YAML configuration and validates it.
+- `-v` forces verbose mode even if `pipeline.verbose` is false in YAML.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,58 @@
+# Configuration
+
+Configuration is read from a YAML file passed with:
+
+```text
+-c <file>
+```
+
+## Example
+
+```yaml
+sdr:
+  device: "rtlsdr"
+  sample_rate_hz: 2048000
+  center_freq_hz: 433920000
+  gain_db: 30
+
+pipeline:
+  verbose: true
+  output_path: "output/frame.bin"
+```
+
+## Sections
+
+### `sdr`
+
+- `device` (`string`)
+- `sample_rate_hz` (`int`)
+- `center_freq_hz` (`int`)
+- `gain_db` (`int`)
+
+### `pipeline`
+
+- `verbose` (`bool`)
+- `output_path` (`string`)
+
+## Defaults
+
+If a key is missing, defaults are used:
+
+- `sdr.device = "rtlsdr"`
+- `sdr.sample_rate_hz = 2048000`
+- `sdr.center_freq_hz = 433920000`
+- `sdr.gain_db = 30`
+- `pipeline.verbose = false`
+- `pipeline.output_path = "output/frame.bin"`
+
+## Validation Rules
+
+- `sdr.sample_rate_hz > 0`
+- `sdr.center_freq_hz > 0`
+- `pipeline.output_path` must not be empty
+
+If validation fails, the app exits with an error.
+
+## CLI Override
+
+- `-v` overrides YAML and forces `pipeline.verbose = true`.


### PR DESCRIPTION
## Summary
- add structured docs in docs/
- simplify root README and link to detailed docs

## Scope
- documentation only