### PR TITLE
feat: add YAML runtime settings, gtest suite, coverage, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI/CD
+
+on:
+  push:
+    branches:
+      - main
+      - lf-*
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build
+
+      - name: Configure
+        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build -j
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    needs: tests
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build
+
+      - name: Install gcovr
+        run: python3 -m pip install --upgrade gcovr
+
+      - name: Configure (coverage)
+        run: cmake -S . -B build-coverage -G Ninja -DCMAKE_BUILD_TYPE=Debug -DLBR_ENABLE_COVERAGE=ON
+
+      - name: Build (coverage)
+        run: cmake --build build-coverage -j
+
+      - name: Run tests (coverage)
+        run: ctest --test-dir build-coverage --output-on-failure
+
+      - name: Generate coverage reports
+        run: |
+          gcovr -r . \
+            --filter '^.*/src/' \
+            --exclude '^.*/build.*/_deps/' \
+            --xml-pretty -o build-coverage/coverage.xml \
+            --html-details -o build-coverage/coverage.html
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            build-coverage/coverage.xml
+            build-coverage/coverage.html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,23 +7,115 @@ cmake_minimum_required(VERSION 3.20)
 
 project(LBR26GroundSoftware VERSION 0.1.0 LANGUAGES CXX)
 
+include(FetchContent)
+include(CTest)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+option(LBR_ENABLE_COVERAGE "Enable gcov coverage instrumentation (GNU only)" OFF)
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0")
+    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+endif()
+
+if(LBR_ENABLE_COVERAGE AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    message(FATAL_ERROR "LBR_ENABLE_COVERAGE requires GNU compiler.")
+endif()
+
+if(LBR_ENABLE_COVERAGE AND NOT BUILD_TESTING)
+    message(FATAL_ERROR "LBR_ENABLE_COVERAGE requires BUILD_TESTING=ON.")
+endif()
+
+FetchContent_Declare(
+    yaml-cpp
+    GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
+    GIT_TAG yaml-cpp-0.9.0
+)
+FetchContent_MakeAvailable(yaml-cpp)
+
+if(BUILD_TESTING)
+    FetchContent_Declare(
+        googletest
+        URL https://github.com/google/googletest/archive/refs/tags/v1.15.2.zip
+    )
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
+endif()
+
+function(lbr_enable_coverage target_name)
+    if(LBR_ENABLE_COVERAGE)
+        target_compile_options(${target_name} PRIVATE -O0 -g --coverage)
+        target_link_options(${target_name} PRIVATE --coverage)
+    endif()
+endfunction()
 
 add_library(cli
     src/cli/args.cc
     src/cli/config.cc
 )
 target_include_directories(cli PUBLIC include)
+target_link_libraries(cli PUBLIC yaml-cpp::yaml-cpp)
+lbr_enable_coverage(cli)
 
 add_library(sdr_pipeline
     src/sdr_pipeline.cc
 )
 target_include_directories(sdr_pipeline PUBLIC include)
 target_link_libraries(sdr_pipeline PUBLIC cli)
+lbr_enable_coverage(sdr_pipeline)
 
 add_executable(lbr_ground
     src/main.cc
 )
 target_link_libraries(lbr_ground PRIVATE sdr_pipeline)
+lbr_enable_coverage(lbr_ground)
+
+if(BUILD_TESTING)
+    add_executable(lbr_tests
+        tests/test_main.cc
+        tests/args_tests.cc
+        tests/config_tests.cc
+        tests/pipeline_tests.cc
+    )
+    target_include_directories(lbr_tests PRIVATE include tests)
+    target_link_libraries(lbr_tests PRIVATE cli sdr_pipeline GTest::gtest)
+    lbr_enable_coverage(lbr_tests)
+
+    add_test(NAME unit_tests COMMAND lbr_tests)
+
+    add_test(NAME app_help COMMAND lbr_ground --help)
+    set_tests_properties(app_help PROPERTIES PASS_REGULAR_EXPRESSION "Usage:")
+
+    add_test(
+        NAME app_demo_config
+        COMMAND lbr_ground -c ${CMAKE_SOURCE_DIR}/config.demo.yaml
+    )
+    set_tests_properties(app_demo_config PROPERTIES PASS_REGULAR_EXPRESSION "Starting SDR pipeline")
+
+    add_test(
+        NAME app_missing_config
+        COMMAND lbr_ground -c ${CMAKE_SOURCE_DIR}/missing-config.yaml
+    )
+    set_tests_properties(app_missing_config PROPERTIES WILL_FAIL TRUE)
+endif()
+
+if(LBR_ENABLE_COVERAGE)
+    find_program(GCOV_EXECUTABLE gcov PATHS C:/msys64/ucrt64/bin)
+    if(NOT GCOV_EXECUTABLE)
+        message(WARNING "gcov not found. Coverage target will not be available.")
+    else()
+        add_custom_target(
+            coverage
+            COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+            COMMAND ${CMAKE_COMMAND} -E rm -rf ${CMAKE_BINARY_DIR}/coverage
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/coverage
+            COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/coverage ${GCOV_EXECUTABLE} -b -c -o ${CMAKE_BINARY_DIR}/CMakeFiles/cli.dir/src/cli ${CMAKE_BINARY_DIR}/CMakeFiles/cli.dir/src/cli/args.cc.obj ${CMAKE_BINARY_DIR}/CMakeFiles/cli.dir/src/cli/config.cc.obj
+            COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/coverage ${GCOV_EXECUTABLE} -b -c -o ${CMAKE_BINARY_DIR}/CMakeFiles/sdr_pipeline.dir/src ${CMAKE_BINARY_DIR}/CMakeFiles/sdr_pipeline.dir/src/sdr_pipeline.cc.obj
+            COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/coverage ${GCOV_EXECUTABLE} -b -c -o ${CMAKE_BINARY_DIR}/CMakeFiles/lbr_ground.dir/src ${CMAKE_BINARY_DIR}/CMakeFiles/lbr_ground.dir/src/main.cc.obj
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            COMMENT "Running tests and generating gcov coverage reports."
+        )
+    endif()
+endif()

--- a/config.demo.yaml
+++ b/config.demo.yaml
@@ -1,5 +1,4 @@
 # Demo configuration file for LBR-26 Ground Software
-# Note: in the current codebase, this file is not parsed yet.
 
 sdr:
   device: "rtlsdr"

--- a/include/cli/config.h
+++ b/include/cli/config.h
@@ -13,6 +13,23 @@
 #include <string_view>
 
 namespace cli {
+    struct SdrSettings {
+        std::string device = "rtlsdr";
+        int sample_rate_hz = 2048000;
+        int center_freq_hz = 433920000;
+        int gain_db = 30;
+    };
+
+    struct PipelineSettings {
+        bool verbose = false;
+        std::string output_path = "output/frame.bin";
+    };
+
+    struct RuntimeSettings {
+        SdrSettings sdr;
+        PipelineSettings pipeline;
+    };
+
     enum class ParseStatus {
         Ok,
         ExitSuccess,
@@ -46,8 +63,22 @@ namespace cli {
              */
             bool verbose() const noexcept;
 
+            /**
+             * @brief Returns parsed runtime settings used by the SDR pipeline.
+             * @return Immutable runtime settings structure.
+             */
+            const RuntimeSettings &settings() const noexcept;
+
         private:
+            /**
+             * @brief Parses settings from the YAML file path stored in this config.
+             * @param error_message Output parse error details when parsing fails.
+             * @return True when config file parsing and validation succeeded.
+             */
+            bool parse_config_file(std::string &error_message);
+
             std::string _config_file;
             bool _verbose = false;
+            RuntimeSettings _settings;
     };
 }

--- a/include/sdr_pipeline.h
+++ b/include/sdr_pipeline.h
@@ -13,9 +13,9 @@ class SDRPipeline {
     public:
         /**
          * @brief Creates the SDR pipeline instance from validated runtime config.
-         * @param config Application configuration produced by CLI parsing.
+         * @param settings Runtime settings produced by CLI and config parsing.
          */
-        explicit SDRPipeline(const cli::Config &config);
+        explicit SDRPipeline(const cli::RuntimeSettings &settings);
 
         /**
          * @brief Starts the SDR processing workflow.
@@ -23,5 +23,5 @@ class SDRPipeline {
         void run();
 
     private:
-        cli::Config _config;
+        cli::RuntimeSettings _settings;
 };

--- a/src/cli/config.cc
+++ b/src/cli/config.cc
@@ -8,8 +8,34 @@
 #include "cli/config.h"
 
 #include <iostream>
+#include <string>
+
+#include <yaml-cpp/yaml.h>
+
+namespace {
+    template <typename T>
+    bool parse_optional_value(const YAML::Node &node,
+                              const char *key,
+                              T &output,
+                              std::string &error_message) {
+        if (!node[key])
+            return true;
+
+        try {
+            output = node[key].as<T>();
+            return true;
+        } catch (const YAML::Exception &e) {
+            error_message = std::string("Invalid value for key '") + key + "': " + e.what();
+            return false;
+        }
+    }
+}
 
 cli::ParseStatus cli::Config::parse(const Args &args) {
+    _config_file.clear();
+    _verbose = false;
+    _settings = RuntimeSettings {};
+
     for (std::size_t i = 1; i < args.size(); ++i) {
         const auto arg = args.at(i);
 
@@ -39,6 +65,18 @@ cli::ParseStatus cli::Config::parse(const Args &args) {
         return ParseStatus::ExitFailure;
     }
 
+    if (!_config_file.empty()) {
+        std::string error_message;
+        if (!parse_config_file(error_message)) {
+            std::cerr << "Failed to parse config file '" << _config_file << "': " << error_message
+                      << '\n';
+            return ParseStatus::ExitFailure;
+        }
+    }
+
+    if (_verbose)
+        _settings.pipeline.verbose = true;
+
     return ParseStatus::Ok;
 }
 
@@ -55,5 +93,74 @@ const std::string &cli::Config::config_file() const noexcept {
 }
 
 bool cli::Config::verbose() const noexcept {
-    return _verbose;
+    return _settings.pipeline.verbose;
+}
+
+const cli::RuntimeSettings &cli::Config::settings() const noexcept {
+    return _settings;
+}
+
+bool cli::Config::parse_config_file(std::string &error_message) {
+    try {
+        const YAML::Node root = YAML::LoadFile(_config_file);
+        if (!root || !root.IsMap()) {
+            error_message = "Root node must be a YAML map.";
+            return false;
+        }
+
+        const YAML::Node sdr_node = root["sdr"];
+        if (sdr_node) {
+            if (!sdr_node.IsMap()) {
+                error_message = "Node 'sdr' must be a map.";
+                return false;
+            }
+
+            if (!parse_optional_value(sdr_node, "device", _settings.sdr.device, error_message))
+                return false;
+            if (!parse_optional_value(
+                    sdr_node, "sample_rate_hz", _settings.sdr.sample_rate_hz, error_message))
+                return false;
+            if (!parse_optional_value(
+                    sdr_node, "center_freq_hz", _settings.sdr.center_freq_hz, error_message))
+                return false;
+            if (!parse_optional_value(sdr_node, "gain_db", _settings.sdr.gain_db, error_message))
+                return false;
+        }
+
+        const YAML::Node pipeline_node = root["pipeline"];
+        if (pipeline_node) {
+            if (!pipeline_node.IsMap()) {
+                error_message = "Node 'pipeline' must be a map.";
+                return false;
+            }
+
+            if (!parse_optional_value(
+                    pipeline_node, "verbose", _settings.pipeline.verbose, error_message))
+                return false;
+            if (!parse_optional_value(
+                    pipeline_node, "output_path", _settings.pipeline.output_path, error_message))
+                return false;
+        }
+
+        if (_settings.sdr.sample_rate_hz <= 0) {
+            error_message = "sdr.sample_rate_hz must be > 0.";
+            return false;
+        }
+        if (_settings.sdr.center_freq_hz <= 0) {
+            error_message = "sdr.center_freq_hz must be > 0.";
+            return false;
+        }
+        if (_settings.pipeline.output_path.empty()) {
+            error_message = "pipeline.output_path must not be empty.";
+            return false;
+        }
+    } catch (const YAML::BadFile &e) {
+        error_message = e.what();
+        return false;
+    } catch (const YAML::Exception &e) {
+        error_message = e.what();
+        return false;
+    }
+
+    return true;
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -44,12 +44,11 @@ int main(int argc, char * const argv[]) {
             return 0;
         case cli::ParseStatus::ExitFailure:
             return 1;
-    default:
-        config.usage(args.program_name());
-        break;
+        case cli::ParseStatus::Ok:
+            break;
     }
 
-    SDRPipeline pipeline(config);
+    SDRPipeline pipeline(config.settings());
 
     try {
         pipeline.run();

--- a/src/sdr_pipeline.cc
+++ b/src/sdr_pipeline.cc
@@ -9,14 +9,16 @@
 
 #include <iostream>
 
-SDRPipeline::SDRPipeline(const cli::Config &config) : _config(config) {}
+SDRPipeline::SDRPipeline(const cli::RuntimeSettings &settings) : _settings(settings) {}
 
 void SDRPipeline::run() {
-    if (_config.verbose()) {
-        std::cout << "Starting SDR pipeline";
-        if (!_config.config_file().empty())
-            std::cout << " with config: " << _config.config_file();
+    if (!_settings.pipeline.verbose)
+        return;
 
-        std::cout << '\n';
-    }
+    std::cout << "Starting SDR pipeline\n"
+              << "  device: " << _settings.sdr.device << '\n'
+              << "  sample_rate_hz: " << _settings.sdr.sample_rate_hz << '\n'
+              << "  center_freq_hz: " << _settings.sdr.center_freq_hz << '\n'
+              << "  gain_db: " << _settings.sdr.gain_db << '\n'
+              << "  output_path: " << _settings.pipeline.output_path << '\n';
 }

--- a/tests/args_tests.cc
+++ b/tests/args_tests.cc
@@ -1,0 +1,42 @@
+/**
+ * @file args_tests.cc
+ * @brief Unit tests for cli::Args
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#include <gtest/gtest.h>
+
+#include "test_common.h"
+
+#include <stdexcept>
+#include <string_view>
+
+TEST(ArgsTests, All) {
+    {
+        tests::ArgvBuilder builder({"app.exe", "-v", "--config"});
+        const cli::Args args = builder.build();
+
+        EXPECT_EQ(args.size(), static_cast<std::size_t>(3));
+        EXPECT_EQ(args.program_name(), std::string_view("app.exe"));
+        EXPECT_EQ(args.at(1), std::string_view("-v"));
+    }
+
+    {
+        char *argv[] = {nullptr};
+        const cli::Args args = cli::Args::from_main(1, argv);
+        EXPECT_EQ(args.program_name(), std::string_view(""));
+    }
+
+    {
+        char **argv = nullptr;
+        const cli::Args args = cli::Args::from_main(0, argv);
+        EXPECT_EQ(args.program_name(), std::string_view("lbr-ground"));
+    }
+
+    {
+        tests::ArgvBuilder builder({"app.exe"});
+        const cli::Args args = builder.build();
+        EXPECT_THROW(static_cast<void>(args.at(5)), std::out_of_range);
+    }
+}

--- a/tests/config_tests.cc
+++ b/tests/config_tests.cc
@@ -1,0 +1,126 @@
+/**
+ * @file config_tests.cc
+ * @brief Unit tests for cli::Config
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#include <gtest/gtest.h>
+
+#include "cli/config.h"
+#include "test_common.h"
+
+#include <string>
+#include <string_view>
+
+namespace {
+    cli::ParseStatus parse_silent(cli::Config &config, const cli::Args &args) {
+        cli::ParseStatus status = cli::ParseStatus::ExitFailure;
+        tests::capture_stdout([&]() {
+            tests::capture_stderr([&]() { status = config.parse(args); });
+        });
+        return status;
+    }
+}
+
+TEST(ConfigTests, All) {
+    {
+        tests::ArgvBuilder builder({"app.exe", "--help"});
+        cli::Config config;
+        EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::ExitSuccess);
+    }
+
+    {
+        tests::ArgvBuilder builder({"app.exe", "--bad-option"});
+        cli::Config config;
+        EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::ExitFailure);
+    }
+
+    {
+        tests::ArgvBuilder builder({"app.exe", "-c"});
+        cli::Config config;
+        EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::ExitFailure);
+    }
+
+    {
+        tests::ArgvBuilder builder({"app.exe", "-v"});
+        cli::Config config;
+        EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::Ok);
+        EXPECT_TRUE(config.verbose());
+    }
+
+    {
+        tests::ScopedTempFile file(
+            "sdr:\n"
+            "  device: \"hackrf\"\n"
+            "  sample_rate_hz: 1000000\n"
+            "  center_freq_hz: 915000000\n"
+            "  gain_db: 12\n"
+            "pipeline:\n"
+            "  verbose: false\n"
+            "  output_path: \"telemetry.bin\"\n");
+
+        tests::ArgvBuilder builder({"app.exe", "-c", file.path().string()});
+        cli::Config config;
+        EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::Ok);
+        EXPECT_EQ(config.config_file(), file.path().string());
+        EXPECT_EQ(config.settings().sdr.device, std::string("hackrf"));
+        EXPECT_EQ(config.settings().sdr.sample_rate_hz, 1000000);
+        EXPECT_EQ(config.settings().sdr.center_freq_hz, 915000000);
+        EXPECT_EQ(config.settings().sdr.gain_db, 12);
+        EXPECT_EQ(config.settings().pipeline.output_path, std::string("telemetry.bin"));
+        EXPECT_FALSE(config.settings().pipeline.verbose);
+    }
+
+    {
+        tests::ScopedTempFile file("pipeline:\n  output_path: \"out.bin\"\n");
+        tests::ArgvBuilder builder({"app.exe", "-c", file.path().string()});
+        cli::Config config;
+        EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::Ok);
+        EXPECT_EQ(config.settings().sdr.device, std::string("rtlsdr"));
+        EXPECT_EQ(config.settings().sdr.sample_rate_hz, 2048000);
+        EXPECT_EQ(config.settings().pipeline.output_path, std::string("out.bin"));
+    }
+
+    {
+        tests::ScopedTempFile file("pipeline:\n  verbose: false\n");
+        tests::ArgvBuilder builder({"app.exe", "-c", file.path().string(), "-v"});
+        cli::Config config;
+        EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::Ok);
+        EXPECT_TRUE(config.verbose());
+    }
+
+    {
+        tests::ArgvBuilder builder({"app.exe", "-c", "missing_file.yaml"});
+        cli::Config config;
+        EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::ExitFailure);
+    }
+
+    {
+        tests::ScopedTempFile file("- item1\n- item2\n");
+        tests::ArgvBuilder builder({"app.exe", "-c", file.path().string()});
+        cli::Config config;
+        EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::ExitFailure);
+    }
+
+    {
+        tests::ScopedTempFile file("sdr:\n  sample_rate_hz: \"fast\"\n");
+        tests::ArgvBuilder builder({"app.exe", "-c", file.path().string()});
+        cli::Config config;
+        EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::ExitFailure);
+    }
+
+    {
+        tests::ScopedTempFile file("sdr:\n  sample_rate_hz: -1\n");
+        tests::ArgvBuilder builder({"app.exe", "-c", file.path().string()});
+        cli::Config config;
+        EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::ExitFailure);
+    }
+
+    {
+        tests::ScopedTempFile file("pipeline:\n  output_path: \"\"\n");
+        tests::ArgvBuilder builder({"app.exe", "-c", file.path().string()});
+        cli::Config config;
+        EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::ExitFailure);
+    }
+}

--- a/tests/pipeline_tests.cc
+++ b/tests/pipeline_tests.cc
@@ -1,0 +1,41 @@
+/**
+ * @file pipeline_tests.cc
+ * @brief Unit tests for SDRPipeline
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#include <gtest/gtest.h>
+
+#include "sdr_pipeline.h"
+#include "test_common.h"
+
+#include <string>
+
+TEST(PipelineTests, All) {
+    {
+        cli::RuntimeSettings settings;
+        settings.pipeline.verbose = false;
+        settings.pipeline.output_path = "silent.bin";
+
+        SDRPipeline pipeline(settings);
+        const std::string output = tests::capture_stdout([&pipeline]() { pipeline.run(); });
+        EXPECT_TRUE(output.empty());
+    }
+
+    {
+        cli::RuntimeSettings settings;
+        settings.pipeline.verbose = true;
+        settings.sdr.device = "rtlsdr";
+        settings.sdr.sample_rate_hz = 2048000;
+        settings.sdr.center_freq_hz = 433920000;
+        settings.sdr.gain_db = 30;
+        settings.pipeline.output_path = "output/frame.bin";
+
+        SDRPipeline pipeline(settings);
+        const std::string output = tests::capture_stdout([&pipeline]() { pipeline.run(); });
+        EXPECT_NE(output.find("Starting SDR pipeline"), std::string::npos);
+        EXPECT_NE(output.find("device: rtlsdr"), std::string::npos);
+        EXPECT_NE(output.find("output_path: output/frame.bin"), std::string::npos);
+    }
+}

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -1,0 +1,79 @@
+/**
+ * @file test_common.h
+ * @brief Shared helpers for unit tests
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#pragma once
+
+#include "cli/args.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace tests {
+    class ArgvBuilder {
+        public:
+            explicit ArgvBuilder(std::initializer_list<std::string> args)
+                : _storage(args) {
+                _argv.reserve(_storage.size());
+                for (std::string &item : _storage)
+                    _argv.push_back(item.data());
+            }
+
+            cli::Args build() {
+                return cli::Args::from_main(static_cast<int>(_argv.size()), _argv.data());
+            }
+
+        private:
+            std::vector<std::string> _storage;
+            std::vector<char *> _argv;
+    };
+
+    class ScopedTempFile {
+        public:
+            explicit ScopedTempFile(const std::string &contents, const std::string &extension = ".yaml") {
+                const auto now = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+                _path = std::filesystem::temp_directory_path() /
+                        ("lbr_test_" + std::to_string(now) + extension);
+
+                std::ofstream out(_path, std::ios::binary);
+                out << contents;
+            }
+
+            ~ScopedTempFile() {
+                std::error_code ec;
+                std::filesystem::remove(_path, ec);
+            }
+
+            const std::filesystem::path &path() const noexcept {
+                return _path;
+            }
+
+        private:
+            std::filesystem::path _path;
+    };
+
+    inline std::string capture_stdout(const std::function<void()> &fn) {
+        std::ostringstream buffer;
+        auto *old_buf = std::cout.rdbuf(buffer.rdbuf());
+        fn();
+        std::cout.rdbuf(old_buf);
+        return buffer.str();
+    }
+
+    inline std::string capture_stderr(const std::function<void()> &fn) {
+        std::ostringstream buffer;
+        auto *old_buf = std::cerr.rdbuf(buffer.rdbuf());
+        fn();
+        std::cerr.rdbuf(old_buf);
+        return buffer.str();
+    }
+}

--- a/tests/test_main.cc
+++ b/tests/test_main.cc
@@ -1,0 +1,13 @@
+/**
+ * @file test_main.cc
+ * @brief GoogleTest runner entrypoint
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- add typed runtime YAML config parsing
- add GoogleTest unit suites and CTest integration checks
- add coverage flow and gcov target
- add GitHub Actions CI workflow for tests and coverage

## Validation
- build + ctest pass locally
- coverage target generates gcov reports