### PR TITLE
refactor(headers): replace pragma once with include guards

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 100
+PointerAlignment: Right
+AllowShortFunctionsOnASingleLine: Empty
+SortIncludes: true

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,9 @@
+Checks: >-
+  clang-analyzer-*,
+  bugprone-*,
+  performance-*,
+  readability-*,
+  modernize-*,-modernize-use-trailing-return-type
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*LoRa/(include|src|tests)/.*'
+FormatStyle: file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,65 @@ jobs:
           path: |
             build-coverage/coverage.xml
             build-coverage/coverage.html
+
+  feature-options:
+    name: Feature Options (ZeroMQ + Protobuf)
+    runs-on: ubuntu-latest
+    needs: tests
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install build tools and optional deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build libzmq3-dev protobuf-compiler python3-pip
+          python3 -m pip install --user nanopb
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Configure with optional features
+        run: cmake -S . -B build-features -G Ninja -DCMAKE_BUILD_TYPE=Release -DLBR_ENABLE_ZEROMQ=ON -DLBR_ENABLE_PROTOBUF_CODEGEN=ON
+
+      - name: Build tests with optional features
+        run: cmake --build build-features -j --target lbr_tests
+
+      - name: Generate protobuf code
+        run: cmake --build build-features --target connector_proto_codegen
+
+      - name: Generate nanopb code
+        run: cmake --build build-features --target connector_nanopb_codegen
+
+      - name: Run ZeroMQ connector test
+        run: ctest --test-dir build-features -R ConnectorTests.LocalZmqTransportPubSubExchange --output-on-failure
+
+  windows-smoke:
+    name: Windows UCRT Smoke
+    runs-on: windows-latest
+    needs: tests
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup MSYS2 UCRT64
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-ninja
+            mingw-w64-ucrt-x86_64-cmake
+
+      - name: Configure
+        shell: powershell
+        run: cmake --preset windows-ucrt-ninja
+
+      - name: Build
+        shell: powershell
+        run: cmake --build --preset windows-ucrt-ninja --target lbr_tests
+
+      - name: Test
+        shell: powershell
+        run: ctest --preset windows-ucrt-ninja

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,4 +4,47 @@ project(LBR26GroundSoftwareRoot LANGUAGES CXX)
 
 include(CTest)
 
+find_package(Doxygen)
+find_program(PDFLATEX_EXECUTABLE pdflatex)
+
+set(LBR_DOXYGEN_OUTPUT_DIR ${CMAKE_BINARY_DIR}/docs/doxygen)
+set(LBR_DOXYGEN_INPUT_DIR ${CMAKE_SOURCE_DIR})
+
+if(DOXYGEN_FOUND)
+	configure_file(
+		${CMAKE_SOURCE_DIR}/docs/Doxyfile.in
+		${CMAKE_BINARY_DIR}/Doxyfile
+		@ONLY
+	)
+
+	add_custom_target(docs
+		COMMAND ${CMAKE_COMMAND} -E make_directory ${LBR_DOXYGEN_OUTPUT_DIR}
+		COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_BINARY_DIR}/Doxyfile
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+		COMMENT "Generating API documentation with Doxygen."
+		VERBATIM
+	)
+else()
+	add_custom_target(docs
+		COMMAND ${CMAKE_COMMAND} -E echo "Doxygen not found in PATH."
+		COMMAND ${CMAKE_COMMAND} -E false
+		COMMENT "Doxygen is required for docs target."
+	)
+endif()
+
+if(DOXYGEN_FOUND AND PDFLATEX_EXECUTABLE)
+	add_custom_target(docs-pdf
+		COMMAND ${CMAKE_COMMAND} -E chdir ${LBR_DOXYGEN_OUTPUT_DIR}/latex cmd /c make.bat
+		DEPENDS docs
+		COMMENT "Generating PDF documentation with Doxygen LaTeX output."
+		VERBATIM
+	)
+else()
+	add_custom_target(docs-pdf
+		COMMAND ${CMAKE_COMMAND} -E echo "Doxygen and pdflatex are required for docs-pdf target."
+		COMMAND ${CMAKE_COMMAND} -E false
+		COMMENT "Missing tools for docs-pdf target."
+	)
+endif()
+
 add_subdirectory(LoRa)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,20 +18,26 @@
         "CMAKE_BUILD_TYPE": "Release"
       },
       "environment": {
-        "PATH": "C:/msys64/ucrt64/bin;$penv{PATH}"
+        "PATH": "C:/msys64/ucrt64/bin;C:/msys64/usr/bin;$penv{PATH}"
       }
     }
   ],
   "buildPresets": [
     {
       "name": "windows-ucrt-ninja",
-      "configurePreset": "windows-ucrt-ninja"
+      "configurePreset": "windows-ucrt-ninja",
+      "environment": {
+        "PATH": "C:/msys64/ucrt64/bin;C:/msys64/usr/bin;$penv{PATH}"
+      }
     }
   ],
   "testPresets": [
     {
       "name": "windows-ucrt-ninja",
       "configurePreset": "windows-ucrt-ninja",
+      "environment": {
+        "PATH": "C:/msys64/ucrt64/bin;C:/msys64/usr/bin;$penv{PATH}"
+      },
       "output": {
         "outputOnFailure": true
       }

--- a/LoRa/CMakeLists.txt
+++ b/LoRa/CMakeLists.txt
@@ -15,10 +15,70 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(LBR_ENABLE_COVERAGE "Enable gcov coverage instrumentation (GNU only)" OFF)
+option(LBR_ENABLE_CLANG_TIDY "Enable clang-tidy while compiling targets" OFF)
+option(LBR_ENABLE_ZEROMQ "Enable ZeroMQ connector transport" OFF)
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0")
     set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 endif()
+
+find_program(CLANG_FORMAT_EXECUTABLE clang-format)
+find_program(CLANG_TIDY_EXECUTABLE clang-tidy)
+
+if(LBR_ENABLE_CLANG_TIDY)
+    if(NOT CLANG_TIDY_EXECUTABLE)
+        message(FATAL_ERROR "LBR_ENABLE_CLANG_TIDY=ON requires clang-tidy in PATH.")
+    endif()
+    set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_EXECUTABLE})
+endif()
+
+file(GLOB_RECURSE LBR_CLANG_SOURCE_FILES CONFIGURE_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cc
+)
+
+if(CLANG_FORMAT_EXECUTABLE)
+    add_custom_target(clang-format
+        COMMAND ${CLANG_FORMAT_EXECUTABLE} -i ${LBR_CLANG_SOURCE_FILES}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMENT "Formatting C++ sources with clang-format."
+    )
+
+    add_custom_target(clang-format-check
+        COMMAND ${CLANG_FORMAT_EXECUTABLE} --dry-run --Werror ${LBR_CLANG_SOURCE_FILES}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMENT "Checking C++ format with clang-format."
+    )
+else()
+    add_custom_target(clang-format
+        COMMAND ${CMAKE_COMMAND} -E echo "clang-format not found in PATH."
+        COMMAND ${CMAKE_COMMAND} -E false
+        COMMENT "clang-format is required for this target."
+    )
+
+    add_custom_target(clang-format-check
+        COMMAND ${CMAKE_COMMAND} -E echo "clang-format not found in PATH."
+        COMMAND ${CMAKE_COMMAND} -E false
+        COMMENT "clang-format is required for this target."
+    )
+endif()
+
+if(CLANG_TIDY_EXECUTABLE)
+    add_custom_target(clang-tidy
+        COMMAND ${CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} ${LBR_CLANG_SOURCE_FILES}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMENT "Running clang-tidy static analysis."
+    )
+else()
+    add_custom_target(clang-tidy
+        COMMAND ${CMAKE_COMMAND} -E echo "clang-tidy not found in PATH."
+        COMMAND ${CMAKE_COMMAND} -E false
+        COMMENT "clang-tidy is required for this target."
+    )
+endif()
+
+add_custom_target(sanity-check DEPENDS clang-format-check clang-tidy)
 
 if(LBR_ENABLE_COVERAGE AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     message(FATAL_ERROR "LBR_ENABLE_COVERAGE requires GNU compiler.")
@@ -86,18 +146,42 @@ add_library(connector
     src/connector/message.cc
     src/connector/ndjson_file.cc
     src/connector/local_tcp_transport.cc
+    src/connector/local_udp_transport.cc
+    src/connector/local_zmq_transport.cc
 )
 target_include_directories(connector PUBLIC include)
+
+set(LBR_HAS_ZEROMQ 0)
+if(LBR_ENABLE_ZEROMQ)
+    find_path(ZMQ_INCLUDE_DIR zmq.h)
+    find_library(ZMQ_LIBRARY NAMES zmq libzmq)
+    if(NOT ZMQ_INCLUDE_DIR OR NOT ZMQ_LIBRARY)
+        message(FATAL_ERROR "LBR_ENABLE_ZEROMQ=ON requires ZeroMQ (zmq.h + libzmq).")
+    endif()
+
+    target_include_directories(connector PRIVATE ${ZMQ_INCLUDE_DIR})
+    target_link_libraries(connector PRIVATE ${ZMQ_LIBRARY})
+    set(LBR_HAS_ZEROMQ 1)
+endif()
+
+target_compile_definitions(connector PUBLIC LBR_HAS_ZEROMQ=${LBR_HAS_ZEROMQ})
+
 if(WIN32)
     target_link_libraries(connector PRIVATE ws2_32)
 endif()
 lbr_enable_coverage(connector)
 
+add_library(telemetry
+    src/telemetry/interpreter.cc
+)
+target_include_directories(telemetry PUBLIC include)
+lbr_enable_coverage(telemetry)
+
 add_library(sdr_pipeline
     src/sdr_pipeline.cc
 )
 target_include_directories(sdr_pipeline PUBLIC include)
-target_link_libraries(sdr_pipeline PUBLIC cli)
+target_link_libraries(sdr_pipeline PUBLIC cli telemetry)
 lbr_enable_coverage(sdr_pipeline)
 
 add_executable(lbr_ground
@@ -159,7 +243,7 @@ if(LBR_ENABLE_COVERAGE)
             COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/coverage ${GCOV_EXECUTABLE} -f -b -c -o ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/cli.dir/src/cli ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/cli.dir/src/cli/args.cc.obj ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/cli.dir/src/cli/config.cc.obj
             COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/coverage ${GCOV_EXECUTABLE} -f -b -c -o ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/sdr_pipeline.dir/src ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/sdr_pipeline.dir/src/sdr_pipeline.cc.obj
             COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/coverage ${GCOV_EXECUTABLE} -f -b -c -o ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/lbr_ground.dir/src ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/lbr_ground.dir/src/main.cc.obj
-            COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/coverage ${GCOV_EXECUTABLE} -f -b -c -o ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/connector.dir/src/connector ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/connector.dir/src/connector/message.cc.obj ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/connector.dir/src/connector/ndjson_file.cc.obj ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/connector.dir/src/connector/local_tcp_transport.cc.obj
+            COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/coverage ${GCOV_EXECUTABLE} -f -b -c -o ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/connector.dir/src/connector ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/connector.dir/src/connector/message.cc.obj ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/connector.dir/src/connector/ndjson_file.cc.obj ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/connector.dir/src/connector/local_tcp_transport.cc.obj ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/connector.dir/src/connector/local_udp_transport.cc.obj
             COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/coverage ${GCOV_EXECUTABLE} -f -b -c -o ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/lora_periph.dir/src/periph ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/lora_periph.dir/src/periph/sx1262_module.cc.obj ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/lora_periph.dir/src/periph/sx127_module.cc.obj
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
             COMMENT "Running tests and generating gcov coverage reports."

--- a/LoRa/CMakeLists.txt
+++ b/LoRa/CMakeLists.txt
@@ -151,6 +151,7 @@ add_library(connector
     src/connector/local_zmq_transport.cc
 )
 target_include_directories(connector PUBLIC include)
+target_link_libraries(connector PRIVATE yaml-cpp::yaml-cpp)
 
 set(LBR_HAS_ZEROMQ 0)
 if(LBR_ENABLE_ZEROMQ)

--- a/LoRa/CMakeLists.txt
+++ b/LoRa/CMakeLists.txt
@@ -193,6 +193,13 @@ target_link_libraries(lbr_ground PRIVATE sdr_pipeline lora_periph)
 lbr_enable_coverage(lbr_ground)
 lbr_copy_gnu_runtime_dlls(lbr_ground)
 
+add_executable(lbr_hil_runner
+    src/hil_runner.cc
+)
+target_link_libraries(lbr_hil_runner PRIVATE lora_periph)
+lbr_enable_coverage(lbr_hil_runner)
+lbr_copy_gnu_runtime_dlls(lbr_hil_runner)
+
 if(BUILD_TESTING)
     include(GoogleTest)
 

--- a/LoRa/CMakeLists.txt
+++ b/LoRa/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 option(LBR_ENABLE_COVERAGE "Enable gcov coverage instrumentation (GNU only)" OFF)
 option(LBR_ENABLE_CLANG_TIDY "Enable clang-tidy while compiling targets" OFF)
 option(LBR_ENABLE_ZEROMQ "Enable ZeroMQ connector transport" OFF)
+option(LBR_ENABLE_PROTOBUF_CODEGEN "Enable connector protobuf/nanopb code generation targets" OFF)
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0")
     set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
@@ -228,6 +229,54 @@ if(BUILD_TESTING)
         COMMAND lbr_ground -c ${CMAKE_CURRENT_SOURCE_DIR}/missing-config.yaml
     )
     set_tests_properties(app_missing_config PROPERTIES WILL_FAIL TRUE)
+endif()
+
+if(LBR_ENABLE_PROTOBUF_CODEGEN)
+    find_program(PROTOC_EXECUTABLE protoc)
+    if(NOT PROTOC_EXECUTABLE)
+        message(FATAL_ERROR "LBR_ENABLE_PROTOBUF_CODEGEN=ON requires protoc in PATH.")
+    endif()
+
+    find_program(PROTOC_GEN_NANOPB_EXECUTABLE
+        NAMES protoc-gen-nanopb nanopb_generator
+    )
+    if(NOT PROTOC_GEN_NANOPB_EXECUTABLE)
+        message(FATAL_ERROR
+            "LBR_ENABLE_PROTOBUF_CODEGEN=ON requires protoc-gen-nanopb (or nanopb_generator) in PATH."
+        )
+    endif()
+
+    set(LBR_PROTO_SRC ${CMAKE_CURRENT_SOURCE_DIR}/docs/connector-message.proto)
+    set(LBR_PROTO_OPTIONS ${CMAKE_CURRENT_SOURCE_DIR}/docs/connector-message.nanopb.options)
+    set(LBR_PROTO_GEN_DIR ${CMAKE_BINARY_DIR}/generated/proto)
+
+    add_custom_target(connector_proto_codegen
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${LBR_PROTO_GEN_DIR}
+        COMMAND ${PROTOC_EXECUTABLE}
+            --proto_path=${CMAKE_CURRENT_SOURCE_DIR}/docs
+            --cpp_out=${LBR_PROTO_GEN_DIR}
+            ${LBR_PROTO_SRC}
+        BYPRODUCTS
+            ${LBR_PROTO_GEN_DIR}/connector-message.pb.cc
+            ${LBR_PROTO_GEN_DIR}/connector-message.pb.h
+        COMMENT "Generating C++ protobuf sources for connector-message.proto"
+        VERBATIM
+    )
+
+    add_custom_target(connector_nanopb_codegen
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${LBR_PROTO_GEN_DIR}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LBR_PROTO_OPTIONS} ${LBR_PROTO_GEN_DIR}/connector-message.options
+        COMMAND ${PROTOC_EXECUTABLE}
+            --proto_path=${CMAKE_CURRENT_SOURCE_DIR}/docs
+            --plugin=protoc-gen-nanopb=${PROTOC_GEN_NANOPB_EXECUTABLE}
+            --nanopb_out=${LBR_PROTO_GEN_DIR}
+            ${LBR_PROTO_SRC}
+        BYPRODUCTS
+            ${LBR_PROTO_GEN_DIR}/connector-message.pb.c
+            ${LBR_PROTO_GEN_DIR}/connector-message.pb.h
+        COMMENT "Generating nanopb sources for connector-message.proto"
+        VERBATIM
+    )
 endif()
 
 if(LBR_ENABLE_COVERAGE)

--- a/LoRa/README.md
+++ b/LoRa/README.md
@@ -5,7 +5,7 @@ Ground software skeleton for the Long Beach Rocketry station, organized under th
 ## What This Update Adds
 
 - A hardware abstraction interface: `periph::ILoRaModule`
-- Two interchangeable backend skeletons:
+- Two interchangeable radio module implementations:
   - `periph::SX1262Module`
   - `periph::SX127Module`
 - `SDRPipeline` now depends on the LoRa abstraction instead of concrete hardware
@@ -51,7 +51,7 @@ LoRa/
 
 ## Module Selection
 
-Choose LoRa backend with either:
+Choose LoRa module and mode with either:
 
 - CLI: `--lora-module sx1262` or `--lora-module sx127`
 - CLI: `--lora-mode virtual` or `--lora-mode hardware`
@@ -119,7 +119,7 @@ Run app:
 .\build\lbr_ground.exe --lora-module sx127 -v
 ```
 
-Hardware-in-the-loop smoke (real SX backend on bench):
+Hardware-in-the-loop smoke (real SX module on bench):
 
 ```powershell
 .\build\lbr_hil_runner.exe --module sx1262 --timeout-ms 5000 --min-bytes 1
@@ -164,9 +164,9 @@ Main project source reports are available in:
 - [build-coverage/coverage/sdr_pipeline.cc.gcov](../build-coverage/coverage/sdr_pipeline.cc.gcov)
 - [build-coverage/coverage/main.cc.gcov](../build-coverage/coverage/main.cc.gcov)
 
-## Current Backend State
+## Current Module State
 
-`SX1262Module` and `SX127Module` are virtual backends for development and CI. They exercise the pipeline contract with deterministic telemetry frames, while hardware-specific SPI/GPIO/radio register logic still remains to be added for production telemetry.
+`SX1262Module` and `SX127Module` are virtual modules for development and CI. They exercise the pipeline contract with deterministic telemetry frames, while hardware-specific SPI/GPIO/radio register logic still remains to be added for production telemetry.
 
 ## Connector
 

--- a/LoRa/README.md
+++ b/LoRa/README.md
@@ -15,9 +15,9 @@ Ground software skeleton for the Long Beach Rocketry station, organized under th
 
 The pipeline now consumes telemetry through `ILoRaModule`:
 
-- `init()`
-- `transmit(uint8_t* buf, size_t len)`
-- `receive(uint8_t* buf)`
+- `init() -> LoRaStatusCode`
+- `transmit(const uint8_t* buf, size_t len) -> LoRaTransmitResult`
+- `receive(uint8_t* buf, size_t max_len, uint32_t timeout_ms) -> LoRaReceiveResult`
 
 Because `SDRPipeline` only sees this interface, switching from SX126x to SX127x does not require pipeline logic changes. The only change is module selection in config/CLI.
 
@@ -26,8 +26,13 @@ Because `SDRPipeline` only sees this interface, switching from SX126x to SX127x 
 ```text
 LoRa/
   include/
+Keyword interface (recommended):
+
+```powershell
+.\dev.ps1 build
+```
     cli/
-      args.h
+Legacy direct entrypoint:
       config.h
     periph/
       i_lora_module.h
@@ -36,16 +41,9 @@ LoRa/
     sdr_pipeline.h
   src/
     cli/
-      args.cc
+.\dev.ps1 build-only
       config.cc
     periph/
-      sx1262_module.cc
-      sx127_module.cc
-    main.cc
-    sdr_pipeline.cc
-  tests/
-    args_tests.cc
-    config_tests.cc
     pipeline_tests.cc
   config.demo.yaml
   CMakeLists.txt
@@ -69,11 +67,45 @@ The CLI option overrides defaults and is validated.
 
 From repository root:
 
+Keyword interface (recommended):
+
 ```powershell
-cmake -S . -B build
-cmake --build build
-ctest --test-dir build --output-on-failure
+.\dev.ps1 build
 ```
+
+Build only (skip tests):
+
+```powershell
+.\dev.ps1 build-only
+```
+
+Sanity checks (when `clang-format` and `clang-tidy` are available in `PATH`):
+
+```powershell
+.\dev.ps1 sanity
+```
+
+If either tool is missing from `PATH`, `sanity-check` fails with a clear message.
+
+Generate API documentation (when `doxygen` is available in `PATH`):
+
+```powershell
+.\dev.ps1 docs
+```
+
+Generate PDF API documentation:
+
+```powershell
+.\dev.ps1 docs-pdf
+```
+
+Generated HTML entry point:
+
+- `build/docs/doxygen/html/index.html`
+
+Generated PDF:
+
+- `build/docs/doxygen/latex/refman.pdf`
 
 Run app:
 
@@ -107,7 +139,7 @@ Project source metrics (all production .cc files):
 Generate coverage from repository root:
 
 ```powershell
-cmake --build build-coverage --target coverage
+.\dev.ps1 coverage
 ```
 
 Coverage artifacts are written to:

--- a/LoRa/README.md
+++ b/LoRa/README.md
@@ -115,6 +115,13 @@ Run app:
 .\build\lbr_ground.exe --lora-module sx127 -v
 ```
 
+Hardware-in-the-loop smoke (real SX backend on bench):
+
+```powershell
+.\build\lbr_hil_runner.exe --module sx1262 --timeout-ms 5000 --min-bytes 1
+.\build\lbr_hil_runner.exe --module sx127 --timeout-ms 5000 --min-bytes 1
+```
+
 ## Coverage
 
 Current score (last run):

--- a/LoRa/README.md
+++ b/LoRa/README.md
@@ -54,18 +54,18 @@ LoRa/
 Choose LoRa backend with either:
 
 - CLI: `--lora-module sx1262` or `--lora-module sx127`
-- CLI: `--lora-backend virtual` or `--lora-backend hardware`
+- CLI: `--lora-mode virtual` or `--lora-mode hardware`
 - YAML:
 
 ```yaml
 lora:
   module: "sx1262"
-  backend: "virtual"
+  mode: "virtual"
 ```
 
 The CLI options override defaults and are validated.
 
-`virtual` is the default backend and is the one that runs in CI. `hardware` is reserved for the future real radio drivers and currently fails fast with a clear message.
+`virtual` is the default mode and is the one that runs in CI. `hardware` is reserved for the future real radio drivers and currently fails fast with a clear message.
 
 ## Build And Run
 

--- a/LoRa/README.md
+++ b/LoRa/README.md
@@ -54,14 +54,18 @@ LoRa/
 Choose LoRa backend with either:
 
 - CLI: `--lora-module sx1262` or `--lora-module sx127`
+- CLI: `--lora-backend virtual` or `--lora-backend hardware`
 - YAML:
 
 ```yaml
 lora:
   module: "sx1262"
+  backend: "virtual"
 ```
 
-The CLI option overrides defaults and is validated.
+The CLI options override defaults and are validated.
+
+`virtual` is the default backend and is the one that runs in CI. `hardware` is reserved for the future real radio drivers and currently fails fast with a clear message.
 
 ## Build And Run
 

--- a/LoRa/README.md
+++ b/LoRa/README.md
@@ -162,7 +162,7 @@ Main project source reports are available in:
 
 ## Current Backend State
 
-`SX1262Module` and `SX127Module` are intentionally skeletal backends. They compile and integrate with the pipeline contract but still need hardware-specific SPI/GPIO/radio register logic for production telemetry.
+`SX1262Module` and `SX127Module` are virtual backends for development and CI. They exercise the pipeline contract with deterministic telemetry frames, while hardware-specific SPI/GPIO/radio register logic still remains to be added for production telemetry.
 
 ## Connector
 
@@ -172,6 +172,8 @@ The implementation lives under [include/connector](include/connector) and [src/c
 
 Short version:
 
-- Preferred transport: local socket for live data exchange.
+- Telemetry live path: local UDP for low-latency reception.
+- Back/front control path: local TCP for ordered exchanges.
+- Back/front fan-out: ZeroMQ when the build enables it.
 - Fallback transport: file-based replay for offline testing and debugging.
 - The transport layer is intentionally separate from the LoRa module abstraction so the other team can implement it without changing the pipeline contract.

--- a/LoRa/README.md
+++ b/LoRa/README.md
@@ -26,13 +26,7 @@ Because `SDRPipeline` only sees this interface, switching from SX126x to SX127x 
 ```text
 LoRa/
   include/
-Keyword interface (recommended):
-
-```powershell
-.\dev.ps1 build
-```
     cli/
-Legacy direct entrypoint:
       config.h
     periph/
       i_lora_module.h
@@ -41,9 +35,15 @@ Legacy direct entrypoint:
     sdr_pipeline.h
   src/
     cli/
-.\dev.ps1 build-only
       config.cc
     periph/
+      sx1262_module.cc
+      sx127_module.cc
+    connector/
+      message.cc
+      local_tcp_transport.cc
+      local_udp_transport.cc
+      local_zmq_transport.cc
     pipeline_tests.cc
   config.demo.yaml
   CMakeLists.txt

--- a/LoRa/config.demo.yaml
+++ b/LoRa/config.demo.yaml
@@ -8,7 +8,7 @@ sdr:
 
 lora:
   module: "sx1262"
-  backend: "virtual"
+  mode: "virtual"
 
 pipeline:
   verbose: true

--- a/LoRa/config.demo.yaml
+++ b/LoRa/config.demo.yaml
@@ -8,6 +8,7 @@ sdr:
 
 lora:
   module: "sx1262"
+  backend: "virtual"
 
 pipeline:
   verbose: true

--- a/LoRa/docs/connector-message.example.json
+++ b/LoRa/docs/connector-message.example.json
@@ -1,9 +1,13 @@
 {
-  "schema_version": 1,
-  "message_type": "telemetry_frame",
+  "schema_version": 2,
+  "message_type": "telemetry_decoded",
   "sequence": 42,
   "timestamp_ms": 1712345678901,
-  "source": "sx1262",
+  "source": "sx1262.custom-v1",
   "payload_b64": "AQIDBA==",
-  "checksum_hex": "4A1F9C2B"
+  "checksum_hex": "4A1F9C2B",
+  "metadata": {
+    "protocol": "lbr.flight.v2",
+    "decoder": "ground-station"
+  }
 }

--- a/LoRa/docs/connector-message.nanopb.options
+++ b/LoRa/docs/connector-message.nanopb.options
@@ -1,0 +1,11 @@
+# Nanopb field constraints for lbr.connector.v1.ConnectorMessage
+# Keep this aligned with connector-message.proto for embedded compatibility.
+
+lbr.connector.v1.ConnectorMessage.message_type max_size:48
+lbr.connector.v1.ConnectorMessage.source max_size:48
+lbr.connector.v1.ConnectorMessage.payload max_size:512
+lbr.connector.v1.ConnectorMessage.checksum_hex max_size:32
+
+# Metadata key/value limits. Adjust if mission profile requires more space.
+lbr.connector.v1.ConnectorMessage.MetadataEntry.key max_size:32
+lbr.connector.v1.ConnectorMessage.MetadataEntry.value max_size:96

--- a/LoRa/docs/connector-message.proto
+++ b/LoRa/docs/connector-message.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package lbr.connector.v1;
+
+message ConnectorMessage {
+  uint32 schema_version = 1;
+  string message_type = 2;
+  uint64 sequence = 3;
+  int64 timestamp_ms = 4;
+  string source = 5;
+  bytes payload = 6;
+  optional string checksum_hex = 7;
+  map<string, string> metadata = 8;
+}

--- a/LoRa/docs/connector-message.schema.json
+++ b/LoRa/docs/connector-message.schema.json
@@ -15,11 +15,11 @@
   "properties": {
     "schema_version": {
       "type": "integer",
-      "const": 1
+      "minimum": 1
     },
     "message_type": {
       "type": "string",
-      "const": "telemetry_frame"
+      "minLength": 1
     },
     "sequence": {
       "type": "integer",
@@ -31,11 +31,11 @@
     },
     "source": {
       "type": "string",
-      "enum": ["sx1262", "sx127", "simulated"]
+      "minLength": 1
     },
     "payload_b64": {
       "type": "string",
-      "minLength": 1
+      "minLength": 0
     },
     "checksum_hex": {
       "type": "string",

--- a/LoRa/docs/connector.md
+++ b/LoRa/docs/connector.md
@@ -7,6 +7,8 @@ The code implementation lives under:
 - [include/connector/message.h](../include/connector/message.h)
 - [include/connector/ndjson_file.h](../include/connector/ndjson_file.h)
 - [include/connector/local_tcp_transport.h](../include/connector/local_tcp_transport.h)
+- [include/connector/local_udp_transport.h](../include/connector/local_udp_transport.h)
+- [include/connector/local_zmq_transport.h](../include/connector/local_zmq_transport.h)
 
 ## Recommendation
 
@@ -23,6 +25,15 @@ Recommended implementation choice:
 
 - On Windows: localhost TCP or a named pipe.
 - On Unix-like systems: localhost TCP or a Unix domain socket.
+
+For low-latency telemetry where producer backpressure must never stall capture,
+prefer local UDP with bounded receive timeouts.
+
+Implementation note in this repository:
+
+- `LocalUdpTransport` is available for timeout-based datagram reads.
+- `LocalTcpTransport` remains available for ordered stream semantics.
+- `LocalZmqTransport` is available for PUB/SUB patterns when built with `-DLBR_ENABLE_ZEROMQ=ON`.
 
 If the consumer side already has a preference, keep the transport behind a small adapter so the pipeline contract does not change.
 
@@ -60,19 +71,28 @@ The connector is not responsible for:
 
 Use the JSON envelope described in [connector-message.schema.json](connector-message.schema.json).
 
+For binary transport, use protobuf with the schema in
+[connector-message.proto](connector-message.proto).
+
+When the flight/embedded side is constrained, use nanopb generated code from the same
+`.proto` schema to keep wire compatibility with the ground side.
+
 Required fields:
 
-- `schema_version`: integer, currently `1`
-- `message_type`: string, currently `telemetry_frame`
+- `schema_version`: integer, `>= 1`
+- `message_type`: non-empty string identifying envelope kind (`telemetry_frame`, `telemetry_decoded`, custom, etc.)
 - `sequence`: monotonically increasing integer starting at `0`
 - `timestamp_ms`: Unix epoch milliseconds
-- `source`: string, one of `sx1262`, `sx127`, or `simulated`
+- `source`: non-empty source identifier (for example `sx1262`, `simulated`, or custom identifiers)
 - `payload_b64`: base64-encoded raw telemetry bytes
 
 Optional fields:
 
 - `checksum_hex`: integrity marker in hexadecimal if the producer wants it
 - `metadata`: extra implementation-specific fields that do not change the contract
+
+The envelope is intentionally extensible so teams can introduce protocol-specific message types
+and source identifiers without changing transport adapters.
 
 Example message:
 
@@ -102,6 +122,9 @@ That structure is enough for the other team to build a consumer without coupling
 Do not let the connector leak into `SDRPipeline` or the LoRa radio abstraction.
 
 The pipeline should continue to depend on `ILoRaModule` only. The connector should remain a separate adapter owned by the consumer-facing layer.
+
+The ground software can optionally perform a lightweight local interpretation pass for operator visibility,
+but this does not change the connector contract and does not replace consumer-side mission interpretation.
 
 ## Notes For The Other Team
 

--- a/LoRa/docs/connector.md
+++ b/LoRa/docs/connector.md
@@ -125,6 +125,6 @@ but this does not change the connector contract and does not replace consumer-si
 
 ## Notes For The Other Team
 
-If they need to change transport later, they should replace only the connector adapter, not the pipeline or radio backends.
+If they need to change transport later, they should replace only the connector adapter, not the pipeline or radio modules.
 
 The formal schema is in [connector-message.schema.json](connector-message.schema.json).

--- a/LoRa/docs/connector.md
+++ b/LoRa/docs/connector.md
@@ -12,22 +12,19 @@ The code implementation lives under:
 
 ## Recommendation
 
-Use a local socket transport for live communication.
+Use the transport that matches the traffic pattern.
 
-Reasoning:
+Recommended split for this repository:
 
-- It keeps data exchange explicit and low-latency.
-- It works well for streaming telemetry frames.
-- It avoids file polling and partial-write ambiguity.
-- It stays usable on the same machine without exposing a network service.
+- Telemetry live path: local UDP.
+- Back/front control or ordered exchange: local TCP.
+- Back/front fan-out or PUB/SUB: ZeroMQ when built with `-DLBR_ENABLE_ZEROMQ=ON`.
 
-Recommended implementation choice:
+Why this split:
 
-- On Windows: localhost TCP or a named pipe.
-- On Unix-like systems: localhost TCP or a Unix domain socket.
-
-For low-latency telemetry where producer backpressure must never stall capture,
-prefer local UDP with bounded receive timeouts.
+- UDP keeps capture low-latency and avoids producer backpressure.
+- TCP preserves ordering and delivery when the front side needs a stable stream.
+- ZeroMQ gives a cleaner adapter boundary when multiple consumers need the same feed.
 
 Implementation note in this repository:
 
@@ -35,7 +32,7 @@ Implementation note in this repository:
 - `LocalTcpTransport` remains available for ordered stream semantics.
 - `LocalZmqTransport` is available for PUB/SUB patterns when built with `-DLBR_ENABLE_ZEROMQ=ON`.
 
-If the consumer side already has a preference, keep the transport behind a small adapter so the pipeline contract does not change.
+Keep the transport behind a small adapter so the pipeline contract does not change.
 
 ## File Transport Fallback
 

--- a/LoRa/docs/protobuf-nanopb.md
+++ b/LoRa/docs/protobuf-nanopb.md
@@ -1,0 +1,37 @@
+# Protobuf / Nanopb Integration
+
+This repository keeps the connector wire schema in:
+
+- `docs/connector-message.proto`
+
+For constrained targets, nanopb can generate bounded C structs from the same schema.
+
+## CMake Targets
+
+Configure with optional code generation enabled:
+
+```powershell
+cmake -S . -B build -DLBR_ENABLE_PROTOBUF_CODEGEN=ON
+```
+
+Generate C++ protobuf sources (ground side):
+
+```powershell
+cmake --build build --target connector_proto_codegen
+```
+
+Generate nanopb sources (embedded side):
+
+```powershell
+cmake --build build --target connector_nanopb_codegen
+```
+
+Generated files are written to:
+
+- `build/generated/proto`
+
+## Notes
+
+- `connector-message.nanopb.options` defines bounded field sizes for nanopb.
+- Keep schema changes backward-compatible when possible (increment semantic contract version in metadata when needed).
+- ZeroMQ/UDP/TCP transports carry serialized bytes; transport and schema evolution should remain decoupled.

--- a/LoRa/docs/protobuf-nanopb.md
+++ b/LoRa/docs/protobuf-nanopb.md
@@ -11,19 +11,19 @@ For constrained targets, nanopb can generate bounded C structs from the same sch
 Configure with optional code generation enabled:
 
 ```powershell
-cmake -S . -B build -DLBR_ENABLE_PROTOBUF_CODEGEN=ON
+.\dev.ps1 proto
 ```
 
 Generate C++ protobuf sources (ground side):
 
 ```powershell
-cmake --build build --target connector_proto_codegen
+.\dev.ps1 proto
 ```
 
 Generate nanopb sources (embedded side):
 
 ```powershell
-cmake --build build --target connector_nanopb_codegen
+.\dev.ps1 nanopb
 ```
 
 Generated files are written to:

--- a/LoRa/include/cli/args.h
+++ b/LoRa/include/cli/args.h
@@ -5,7 +5,8 @@
  * @note Origin: Long Beach Rocketry
  */
 
-#pragma once
+#ifndef LORA_INCLUDE_CLI_ARGS_H_
+#define LORA_INCLUDE_CLI_ARGS_H_
 
 #include <cstddef>
 #include <string_view>
@@ -45,3 +46,5 @@ namespace cli {
             std::vector<std::string_view> _values;
     };
 }
+
+#endif  // LORA_INCLUDE_CLI_ARGS_H_

--- a/LoRa/include/cli/config.h
+++ b/LoRa/include/cli/config.h
@@ -28,7 +28,7 @@ namespace cli {
 
     struct LoRaSettings {
         std::string module = "sx1262";
-        std::string backend = "virtual";
+        std::string mode = "virtual";
     };
 
     struct RuntimeSettings {

--- a/LoRa/include/cli/config.h
+++ b/LoRa/include/cli/config.h
@@ -28,6 +28,7 @@ namespace cli {
 
     struct LoRaSettings {
         std::string module = "sx1262";
+        std::string backend = "virtual";
     };
 
     struct RuntimeSettings {

--- a/LoRa/include/cli/config.h
+++ b/LoRa/include/cli/config.h
@@ -23,6 +23,7 @@ namespace cli {
     struct PipelineSettings {
         bool verbose = false;
         std::string output_path = "output/frame.bin";
+        bool interpret_telemetry = true;
     };
 
     struct LoRaSettings {

--- a/LoRa/include/cli/config.h
+++ b/LoRa/include/cli/config.h
@@ -5,7 +5,8 @@
  * @note Origin: Long Beach Rocketry
  */
 
-#pragma once
+#ifndef LORA_INCLUDE_CLI_CONFIG_H_
+#define LORA_INCLUDE_CLI_CONFIG_H_
 
 #include "cli/args.h"
 
@@ -89,3 +90,5 @@ namespace cli {
             RuntimeSettings _settings;
     };
 }
+
+#endif  // LORA_INCLUDE_CLI_CONFIG_H_

--- a/LoRa/include/connector/local_tcp_transport.h
+++ b/LoRa/include/connector/local_tcp_transport.h
@@ -5,7 +5,8 @@
  * @note Origin: Long Beach Rocketry
  */
 
-#pragma once
+#ifndef LORA_INCLUDE_CONNECTOR_LOCAL_TCP_TRANSPORT_H_
+#define LORA_INCLUDE_CONNECTOR_LOCAL_TCP_TRANSPORT_H_
 
 #include <cstdint>
 #include <string>
@@ -101,3 +102,5 @@ namespace connector {
 #endif
     };
 }
+
+#endif  // LORA_INCLUDE_CONNECTOR_LOCAL_TCP_TRANSPORT_H_

--- a/LoRa/include/connector/local_udp_transport.h
+++ b/LoRa/include/connector/local_udp_transport.h
@@ -1,0 +1,90 @@
+/**
+ * @file local_udp_transport.h
+ * @brief Local UDP transport for connector messages
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace connector {
+    /**
+     * @brief Role of the local UDP transport endpoint.
+     */
+    enum class LocalUdpMode {
+        Server,
+        Client
+    };
+
+    /**
+     * @brief Minimal datagram-based local UDP transport used by the connector layer.
+     *
+     * Reads can be performed with a timeout so callers avoid indefinite blocking.
+     */
+    class LocalUdpTransport {
+        public:
+            /**
+             * @brief Creates a local UDP endpoint descriptor.
+             * @param mode Endpoint role (server/client).
+             * @param host IPv4 host or localhost.
+             * @param port UDP port number.
+             */
+            LocalUdpTransport(LocalUdpMode mode, std::string host, std::uint16_t port);
+
+            /**
+             * @brief Releases socket resources when the object goes out of scope.
+             */
+            ~LocalUdpTransport();
+
+            /**
+             * @brief Opens the UDP socket and binds/connects as needed.
+             * @throws std::runtime_error on socket creation, bind, or connect failure.
+             */
+            void open();
+
+            /**
+             * @brief Closes active socket handles.
+             */
+            void close() noexcept;
+
+            /**
+             * @brief Sends one datagram payload.
+             * @param payload Datagram bytes to send.
+             * @throws std::runtime_error when the transport is not open or send fails.
+             */
+            void write_datagram(const std::string &payload);
+
+            /**
+             * @brief Reads one datagram payload with timeout.
+             * @param payload Output datagram payload.
+             * @param timeout_ms Maximum wait in milliseconds.
+             * @return True when one datagram is read, false when timeout occurs.
+             * @throws std::runtime_error when the transport is not open or recv fails.
+             */
+            bool read_datagram(std::string &payload, std::uint32_t timeout_ms);
+
+        private:
+            void ensure_open() const;
+
+            LocalUdpMode _mode;
+            std::string _host;
+            std::uint16_t _port;
+            bool _is_open = false;
+            bool _has_peer = false;
+
+#ifdef _WIN32
+            using SocketHandle = std::intptr_t;
+            SocketHandle _socket = -1;
+            std::string _peer_ip;
+            std::uint16_t _peer_port = 0;
+#else
+            using SocketHandle = int;
+            SocketHandle _socket = -1;
+            std::string _peer_ip;
+            std::uint16_t _peer_port = 0;
+#endif
+    };
+}

--- a/LoRa/include/connector/local_udp_transport.h
+++ b/LoRa/include/connector/local_udp_transport.h
@@ -5,7 +5,8 @@
  * @note Origin: Long Beach Rocketry
  */
 
-#pragma once
+#ifndef LORA_INCLUDE_CONNECTOR_LOCAL_UDP_TRANSPORT_H_
+#define LORA_INCLUDE_CONNECTOR_LOCAL_UDP_TRANSPORT_H_
 
 #include <cstdint>
 #include <string>
@@ -88,3 +89,5 @@ namespace connector {
 #endif
     };
 }
+
+#endif  // LORA_INCLUDE_CONNECTOR_LOCAL_UDP_TRANSPORT_H_

--- a/LoRa/include/connector/local_zmq_transport.h
+++ b/LoRa/include/connector/local_zmq_transport.h
@@ -5,7 +5,8 @@
  * @note Origin: Long Beach Rocketry
  */
 
-#pragma once
+#ifndef LORA_INCLUDE_CONNECTOR_LOCAL_ZMQ_TRANSPORT_H_
+#define LORA_INCLUDE_CONNECTOR_LOCAL_ZMQ_TRANSPORT_H_
 
 #include <cstdint>
 #include <string>
@@ -79,3 +80,5 @@ namespace connector {
             Impl *_impl = nullptr;
     };
 }
+
+#endif  // LORA_INCLUDE_CONNECTOR_LOCAL_ZMQ_TRANSPORT_H_

--- a/LoRa/include/connector/local_zmq_transport.h
+++ b/LoRa/include/connector/local_zmq_transport.h
@@ -1,0 +1,81 @@
+/**
+ * @file local_zmq_transport.h
+ * @brief Optional local ZeroMQ transport for connector messages
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace connector {
+    /**
+     * @brief Role of the local ZeroMQ endpoint.
+     */
+    enum class LocalZmqMode {
+        Publisher,
+        Subscriber
+    };
+
+    /**
+     * @brief Topic-based local ZeroMQ transport.
+     *
+     * This class is compiled in all builds. Actual ZeroMQ behavior is enabled only
+     * when CMake sets LBR_HAS_ZEROMQ=1.
+     */
+    class LocalZmqTransport {
+        public:
+            /**
+             * @brief Creates a ZeroMQ endpoint descriptor.
+             * @param mode Endpoint role (publisher/subscriber).
+             * @param endpoint ZeroMQ endpoint string (e.g. tcp://127.0.0.1:5560).
+             * @param topic Topic prefix used by publisher/subscriber filtering.
+             */
+            LocalZmqTransport(LocalZmqMode mode, std::string endpoint, std::string topic);
+
+            /**
+             * @brief Releases underlying resources.
+             */
+            ~LocalZmqTransport();
+
+            /**
+             * @brief Opens the transport endpoint.
+             * @throws std::runtime_error on failure or when ZeroMQ is not available.
+             */
+            void open();
+
+            /**
+             * @brief Closes the transport endpoint.
+             */
+            void close() noexcept;
+
+            /**
+             * @brief Sends one topic-framed payload.
+             * @param payload Payload bytes.
+             * @throws std::runtime_error on failure.
+             */
+            void send_message(const std::string &payload);
+
+            /**
+             * @brief Reads one payload with timeout.
+             * @param payload Output payload bytes.
+             * @param timeout_ms Maximum wait in milliseconds.
+             * @return True if payload is received, false on timeout.
+             * @throws std::runtime_error on failure.
+             */
+            bool receive_message(std::string &payload, std::int32_t timeout_ms);
+
+        private:
+            void ensure_open() const;
+
+            LocalZmqMode _mode;
+            std::string _endpoint;
+            std::string _topic;
+            bool _is_open = false;
+
+            struct Impl;
+            Impl *_impl = nullptr;
+    };
+}

--- a/LoRa/include/connector/message.h
+++ b/LoRa/include/connector/message.h
@@ -47,7 +47,7 @@ namespace connector {
         std::string message_type = "telemetry_frame";
         std::uint64_t sequence = 0;
         std::int64_t timestamp_ms = 0;
-        Source source = Source::Simulated;
+        std::string source = "simulated";
         std::vector<std::uint8_t> payload;
         std::optional<std::string> checksum_hex;
         std::map<std::string, std::string> metadata;
@@ -55,7 +55,7 @@ namespace connector {
         /**
          * @brief Serializes this message into a JSON object string matching the connector contract.
          * @return JSON string for one connector message.
-         * @throws std::runtime_error when the schema version or message type is unsupported.
+         * @throws std::runtime_error when required envelope fields are invalid.
          */
         std::string to_json() const;
 

--- a/LoRa/include/connector/message.h
+++ b/LoRa/include/connector/message.h
@@ -5,7 +5,8 @@
  * @note Origin: Long Beach Rocketry
  */
 
-#pragma once
+#ifndef LORA_INCLUDE_CONNECTOR_MESSAGE_H_
+#define LORA_INCLUDE_CONNECTOR_MESSAGE_H_
 
 #include <cstdint>
 #include <map>
@@ -68,3 +69,5 @@ namespace connector {
         static ConnectorMessage from_json(const std::string &json_text);
     };
 }
+
+#endif  // LORA_INCLUDE_CONNECTOR_MESSAGE_H_

--- a/LoRa/include/connector/ndjson_file.h
+++ b/LoRa/include/connector/ndjson_file.h
@@ -5,7 +5,8 @@
  * @note Origin: Long Beach Rocketry
  */
 
-#pragma once
+#ifndef LORA_INCLUDE_CONNECTOR_NDJSON_FILE_H_
+#define LORA_INCLUDE_CONNECTOR_NDJSON_FILE_H_
 
 #include "connector/message.h"
 
@@ -62,3 +63,5 @@ namespace connector {
             std::string _line_buffer;
     };
 }
+
+#endif  // LORA_INCLUDE_CONNECTOR_NDJSON_FILE_H_

--- a/LoRa/include/periph/i_lora_module.h
+++ b/LoRa/include/periph/i_lora_module.h
@@ -5,7 +5,8 @@
  * @note Origin: Long Beach Rocketry
  */
 
-#pragma once
+#ifndef LORA_INCLUDE_PERIPH_I_LORA_MODULE_H_
+#define LORA_INCLUDE_PERIPH_I_LORA_MODULE_H_
 
 #include <cstddef>
 #include <cstdint>
@@ -71,3 +72,5 @@ namespace periph {
             virtual LoRaReceiveResult receive(uint8_t *buf, size_t max_len, uint32_t timeout_ms) = 0;
     };
 }
+
+#endif  // LORA_INCLUDE_PERIPH_I_LORA_MODULE_H_

--- a/LoRa/include/periph/i_lora_module.h
+++ b/LoRa/include/periph/i_lora_module.h
@@ -39,7 +39,7 @@ namespace periph {
     };
 
     /**
-     * @brief Interface implemented by all LoRa radio backends.
+     * @brief Interface implemented by all LoRa radio modules.
      *
      * SDRPipeline depends on this abstraction to stay hardware-agnostic.
      */
@@ -48,7 +48,7 @@ namespace periph {
             virtual ~ILoRaModule() = default;
 
             /**
-             * @brief Initialize the LoRa radio backend.
+             * @brief Initialize the LoRa radio module.
              * @return Initialization status.
              */
             virtual LoRaStatusCode init() = 0;
@@ -57,12 +57,12 @@ namespace periph {
              * @brief Transmit a telemetry payload.
              * @param buf Pointer to payload bytes.
              * @param len Number of bytes to send.
-             * @return Transmit status and bytes written to radio backend.
+             * @return Transmit status and bytes written to the radio module.
              */
             virtual LoRaTransmitResult transmit(const uint8_t *buf, size_t len) = 0;
 
             /**
-             * @brief Receive telemetry bytes from the LoRa backend.
+             * @brief Receive telemetry bytes from the LoRa module.
              * @param buf Destination buffer.
              * @param max_len Capacity of destination buffer.
              * @param timeout_ms Maximum wait for a frame in milliseconds.

--- a/LoRa/include/periph/i_lora_module.h
+++ b/LoRa/include/periph/i_lora_module.h
@@ -11,6 +11,33 @@
 #include <cstdint>
 
 namespace periph {
+    enum class LoRaStatusCode {
+        Ok,
+        Timeout,
+        InvalidArgument,
+        NotInitialized,
+        IoError,
+        Unsupported,
+        UnknownError,
+    };
+
+    struct LoRaSignalMetrics {
+        bool has_signal_metrics = false;
+        int rssi_dbm = 0;
+        float snr_db = 0.0F;
+    };
+
+    struct LoRaTransmitResult {
+        LoRaStatusCode status = LoRaStatusCode::UnknownError;
+        size_t bytes_transmitted = 0;
+    };
+
+    struct LoRaReceiveResult {
+        LoRaStatusCode status = LoRaStatusCode::UnknownError;
+        size_t bytes_received = 0;
+        LoRaSignalMetrics signal;
+    };
+
     /**
      * @brief Interface implemented by all LoRa radio backends.
      *
@@ -22,22 +49,25 @@ namespace periph {
 
             /**
              * @brief Initialize the LoRa radio backend.
-             * @return True if initialization succeeds.
+             * @return Initialization status.
              */
-            virtual bool init() = 0;
+            virtual LoRaStatusCode init() = 0;
 
             /**
              * @brief Transmit a telemetry payload.
              * @param buf Pointer to payload bytes.
              * @param len Number of bytes to send.
+             * @return Transmit status and bytes written to radio backend.
              */
-            virtual void transmit(uint8_t *buf, size_t len) = 0;
+            virtual LoRaTransmitResult transmit(const uint8_t *buf, size_t len) = 0;
 
             /**
              * @brief Receive telemetry bytes from the LoRa backend.
              * @param buf Destination buffer.
-             * @return Number of bytes received.
+             * @param max_len Capacity of destination buffer.
+             * @param timeout_ms Maximum wait for a frame in milliseconds.
+             * @return Receive status, bytes received, and optional signal metrics.
              */
-            virtual int receive(uint8_t *buf) = 0;
+            virtual LoRaReceiveResult receive(uint8_t *buf, size_t max_len, uint32_t timeout_ms) = 0;
     };
 }

--- a/LoRa/include/periph/sx1262_module.h
+++ b/LoRa/include/periph/sx1262_module.h
@@ -15,8 +15,8 @@ namespace periph {
      */
     class SX1262Module final : public ILoRaModule {
         public:
-            bool init() override;
-            void transmit(uint8_t *buf, size_t len) override;
-            int receive(uint8_t *buf) override;
+            LoRaStatusCode init() override;
+            LoRaTransmitResult transmit(const uint8_t *buf, size_t len) override;
+            LoRaReceiveResult receive(uint8_t *buf, size_t max_len, uint32_t timeout_ms) override;
     };
 }

--- a/LoRa/include/periph/sx1262_module.h
+++ b/LoRa/include/periph/sx1262_module.h
@@ -1,6 +1,6 @@
 /**
  * @file sx1262_module.h
- * @brief Skeleton SX1262 LoRa backend
+ * @brief Virtual SX1262 LoRa module
  * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
  * @note Origin: Long Beach Rocketry
  */
@@ -14,7 +14,7 @@
 
 namespace periph {
     /**
-     * @brief Virtual SX1262 backend used by the current pipeline.
+    * @brief Virtual SX1262 module used by the current pipeline.
      */
     class SX1262Module final : public ILoRaModule {
         public:

--- a/LoRa/include/periph/sx1262_module.h
+++ b/LoRa/include/periph/sx1262_module.h
@@ -5,7 +5,8 @@
  * @note Origin: Long Beach Rocketry
  */
 
-#pragma once
+#ifndef LORA_INCLUDE_PERIPH_SX1262_MODULE_H_
+#define LORA_INCLUDE_PERIPH_SX1262_MODULE_H_
 
 #include "periph/i_lora_module.h"
 
@@ -28,3 +29,5 @@ namespace periph {
             std::deque<std::vector<std::uint8_t>> _pending_frames;
     };
 }
+
+#endif  // LORA_INCLUDE_PERIPH_SX1262_MODULE_H_

--- a/LoRa/include/periph/sx1262_module.h
+++ b/LoRa/include/periph/sx1262_module.h
@@ -9,9 +9,12 @@
 
 #include "periph/i_lora_module.h"
 
+#include <deque>
+#include <vector>
+
 namespace periph {
     /**
-     * @brief SX1262 placeholder implementation used by the current pipeline.
+     * @brief Virtual SX1262 backend used by the current pipeline.
      */
     class SX1262Module final : public ILoRaModule {
         public:
@@ -21,5 +24,7 @@ namespace periph {
 
         private:
             bool _initialized = false;
+            bool _default_frame_emitted = false;
+            std::deque<std::vector<std::uint8_t>> _pending_frames;
     };
 }

--- a/LoRa/include/periph/sx1262_module.h
+++ b/LoRa/include/periph/sx1262_module.h
@@ -18,5 +18,8 @@ namespace periph {
             LoRaStatusCode init() override;
             LoRaTransmitResult transmit(const uint8_t *buf, size_t len) override;
             LoRaReceiveResult receive(uint8_t *buf, size_t max_len, uint32_t timeout_ms) override;
+
+        private:
+            bool _initialized = false;
     };
 }

--- a/LoRa/include/periph/sx127_module.h
+++ b/LoRa/include/periph/sx127_module.h
@@ -5,7 +5,8 @@
  * @note Origin: Long Beach Rocketry
  */
 
-#pragma once
+#ifndef LORA_INCLUDE_PERIPH_SX127_MODULE_H_
+#define LORA_INCLUDE_PERIPH_SX127_MODULE_H_
 
 #include "periph/i_lora_module.h"
 
@@ -28,3 +29,5 @@ namespace periph {
             std::deque<std::vector<std::uint8_t>> _pending_frames;
     };
 }
+
+#endif  // LORA_INCLUDE_PERIPH_SX127_MODULE_H_

--- a/LoRa/include/periph/sx127_module.h
+++ b/LoRa/include/periph/sx127_module.h
@@ -9,9 +9,12 @@
 
 #include "periph/i_lora_module.h"
 
+#include <deque>
+#include <vector>
+
 namespace periph {
     /**
-     * @brief SX127 placeholder implementation for compatibility testing.
+     * @brief Virtual SX127 backend used by the current pipeline.
      */
     class SX127Module final : public ILoRaModule {
         public:
@@ -21,5 +24,7 @@ namespace periph {
 
         private:
             bool _initialized = false;
+            bool _default_frame_emitted = false;
+            std::deque<std::vector<std::uint8_t>> _pending_frames;
     };
 }

--- a/LoRa/include/periph/sx127_module.h
+++ b/LoRa/include/periph/sx127_module.h
@@ -15,8 +15,8 @@ namespace periph {
      */
     class SX127Module final : public ILoRaModule {
         public:
-            bool init() override;
-            void transmit(uint8_t *buf, size_t len) override;
-            int receive(uint8_t *buf) override;
+            LoRaStatusCode init() override;
+            LoRaTransmitResult transmit(const uint8_t *buf, size_t len) override;
+            LoRaReceiveResult receive(uint8_t *buf, size_t max_len, uint32_t timeout_ms) override;
     };
 }

--- a/LoRa/include/periph/sx127_module.h
+++ b/LoRa/include/periph/sx127_module.h
@@ -1,6 +1,6 @@
 /**
  * @file sx127_module.h
- * @brief Skeleton SX127 LoRa backend
+ * @brief Virtual SX127 LoRa module
  * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
  * @note Origin: Long Beach Rocketry
  */
@@ -14,7 +14,7 @@
 
 namespace periph {
     /**
-     * @brief Virtual SX127 backend used by the current pipeline.
+    * @brief Virtual SX127 module used by the current pipeline.
      */
     class SX127Module final : public ILoRaModule {
         public:

--- a/LoRa/include/periph/sx127_module.h
+++ b/LoRa/include/periph/sx127_module.h
@@ -18,5 +18,8 @@ namespace periph {
             LoRaStatusCode init() override;
             LoRaTransmitResult transmit(const uint8_t *buf, size_t len) override;
             LoRaReceiveResult receive(uint8_t *buf, size_t max_len, uint32_t timeout_ms) override;
+
+        private:
+            bool _initialized = false;
     };
 }

--- a/LoRa/include/sdr_pipeline.h
+++ b/LoRa/include/sdr_pipeline.h
@@ -5,7 +5,8 @@
  * @note Origin: Long Beach Rocketry
  */
 
-#pragma once
+#ifndef LORA_INCLUDE_SDR_PIPELINE_H_
+#define LORA_INCLUDE_SDR_PIPELINE_H_
 
 #include "cli/config.h"
 #include "periph/i_lora_module.h"
@@ -28,3 +29,5 @@ class SDRPipeline {
         cli::RuntimeSettings _settings;
         periph::ILoRaModule &_lora_module;
 };
+
+    #endif  // LORA_INCLUDE_SDR_PIPELINE_H_

--- a/LoRa/include/sdr_pipeline.h
+++ b/LoRa/include/sdr_pipeline.h
@@ -15,9 +15,9 @@ class SDRPipeline {
         /**
          * @brief Creates the SDR pipeline instance from validated runtime config.
          * @param settings Runtime settings produced by CLI and config parsing.
-         * @param lora_module LoRa peripheral abstraction used to receive telemetry bytes.
+         * @param lora_module Non-null LoRa peripheral abstraction used to receive telemetry bytes.
          */
-        explicit SDRPipeline(const cli::RuntimeSettings &settings, periph::ILoRaModule *lora_module);
+        explicit SDRPipeline(const cli::RuntimeSettings &settings, periph::ILoRaModule &lora_module);
 
         /**
          * @brief Starts the SDR processing workflow.
@@ -26,5 +26,5 @@ class SDRPipeline {
 
     private:
         cli::RuntimeSettings _settings;
-        periph::ILoRaModule *_lora_module;
+        periph::ILoRaModule &_lora_module;
 };

--- a/LoRa/include/telemetry/interpreter.h
+++ b/LoRa/include/telemetry/interpreter.h
@@ -5,7 +5,8 @@
  * @note Origin: Long Beach Rocketry
  */
 
-#pragma once
+#ifndef LORA_INCLUDE_TELEMETRY_INTERPRETER_H_
+#define LORA_INCLUDE_TELEMETRY_INTERPRETER_H_
 
 #include <cstddef>
 #include <cstdint>
@@ -28,3 +29,5 @@ namespace telemetry {
             static DecodedTelemetry decode(const uint8_t *payload, size_t payload_len);
     };
 }
+
+#endif  // LORA_INCLUDE_TELEMETRY_INTERPRETER_H_

--- a/LoRa/include/telemetry/interpreter.h
+++ b/LoRa/include/telemetry/interpreter.h
@@ -1,0 +1,30 @@
+/**
+ * @file interpreter.h
+ * @brief Lightweight telemetry payload interpreter
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace telemetry {
+    struct DecodedTelemetry {
+        bool decoded = false;
+        std::string summary;
+    };
+
+    class Interpreter {
+        public:
+            /**
+             * @brief Attempts to decode a telemetry payload into a human-readable summary.
+             * @param payload Pointer to payload bytes.
+             * @param payload_len Number of payload bytes.
+             * @return Decode status and summary text.
+             */
+            static DecodedTelemetry decode(const uint8_t *payload, size_t payload_len);
+    };
+}

--- a/LoRa/src/cli/config.cc
+++ b/LoRa/src/cli/config.cc
@@ -168,16 +168,16 @@ bool cli::Config::parse_config_file(std::string &error_message) {
                 return false;
         }
 
-            const YAML::Node lora_node = root["lora"];
-            if (lora_node) {
-                if (!lora_node.IsMap()) {
-                    error_message = "Node 'lora' must be a map.";
-                    return false;
-                }
-
-                if (!parse_optional_value(lora_node, "module", _settings.lora.module, error_message))
-                    return false;
+        const YAML::Node lora_node = root["lora"];
+        if (lora_node) {
+            if (!lora_node.IsMap()) {
+                error_message = "Node 'lora' must be a map.";
+                return false;
             }
+
+            if (!parse_optional_value(lora_node, "module", _settings.lora.module, error_message))
+                return false;
+        }
 
         if (_settings.sdr.sample_rate_hz <= 0) {
             error_message = "sdr.sample_rate_hz must be > 0.";

--- a/LoRa/src/cli/config.cc
+++ b/LoRa/src/cli/config.cc
@@ -161,6 +161,11 @@ bool cli::Config::parse_config_file(std::string &error_message) {
             if (!parse_optional_value(
                     pipeline_node, "output_path", _settings.pipeline.output_path, error_message))
                 return false;
+            if (!parse_optional_value(pipeline_node,
+                                      "interpret_telemetry",
+                                      _settings.pipeline.interpret_telemetry,
+                                      error_message))
+                return false;
         }
 
             const YAML::Node lora_node = root["lora"];

--- a/LoRa/src/cli/config.cc
+++ b/LoRa/src/cli/config.cc
@@ -34,8 +34,8 @@ namespace {
         return module_name == "sx1262" || module_name == "sx127";
     }
 
-    bool is_supported_lora_backend(const std::string &backend_name) {
-        return backend_name == "virtual" || backend_name == "hardware";
+    bool is_supported_lora_mode(const std::string &mode_name) {
+        return mode_name == "virtual" || mode_name == "hardware";
     }
 }
 
@@ -84,16 +84,16 @@ cli::ParseStatus cli::Config::parse(const Args &args) {
             continue;
         }
 
-        if (arg == "-b" || arg == "--lora-backend") {
+        if (arg == "-b" || arg == "--lora-mode") {
             if (i + 1 >= args.size()) {
                 std::cerr << "Missing value for option: " << arg << '\n';
                 usage(args.program_name());
                 return ParseStatus::ExitFailure;
             }
 
-            _settings.lora.backend = std::string(args.at(++i));
-            if (!is_supported_lora_backend(_settings.lora.backend)) {
-                std::cerr << "Unsupported LoRa backend: " << _settings.lora.backend << '\n';
+            _settings.lora.mode = std::string(args.at(++i));
+            if (!is_supported_lora_mode(_settings.lora.mode)) {
+                std::cerr << "Unsupported LoRa mode: " << _settings.lora.mode << '\n';
                 usage(args.program_name());
                 return ParseStatus::ExitFailure;
             }
@@ -126,7 +126,7 @@ void cli::Config::usage(std::string_view program_name) const {
               << "  -h, --help            Show this help message and exit\n"
               << "  -c, --config <file>   Path to configuration file\n"
               << "  -m, --lora-module <name>  LoRa module (sx1262 or sx127)\n"
-              << "  -b, --lora-backend <name> LoRa backend (virtual or hardware)\n"
+              << "  -b, --lora-mode <name> LoRa mode (virtual or hardware)\n"
               << "  -v, --verbose         Enable verbose output" << std::endl;
 }
 
@@ -199,8 +199,8 @@ bool cli::Config::parse_config_file(std::string &error_message) {
             if (!parse_optional_value(lora_node, "module", _settings.lora.module, error_message))
                 return false;
             if (!parse_optional_value(lora_node,
-                                      "backend",
-                                      _settings.lora.backend,
+                                      "mode",
+                                      _settings.lora.mode,
                                       error_message))
                 return false;
         }
@@ -221,8 +221,8 @@ bool cli::Config::parse_config_file(std::string &error_message) {
             error_message = "lora.module must be one of: sx1262, sx127.";
             return false;
         }
-        if (!is_supported_lora_backend(_settings.lora.backend)) {
-            error_message = "lora.backend must be one of: virtual, hardware.";
+        if (!is_supported_lora_mode(_settings.lora.mode)) {
+            error_message = "lora.mode must be one of: virtual, hardware.";
             return false;
         }
     } catch (const YAML::BadFile &e) {

--- a/LoRa/src/cli/config.cc
+++ b/LoRa/src/cli/config.cc
@@ -33,6 +33,10 @@ namespace {
     bool is_supported_lora_module(const std::string &module_name) {
         return module_name == "sx1262" || module_name == "sx127";
     }
+
+    bool is_supported_lora_backend(const std::string &backend_name) {
+        return backend_name == "virtual" || backend_name == "hardware";
+    }
 }
 
 cli::ParseStatus cli::Config::parse(const Args &args) {
@@ -80,6 +84,22 @@ cli::ParseStatus cli::Config::parse(const Args &args) {
             continue;
         }
 
+        if (arg == "-b" || arg == "--lora-backend") {
+            if (i + 1 >= args.size()) {
+                std::cerr << "Missing value for option: " << arg << '\n';
+                usage(args.program_name());
+                return ParseStatus::ExitFailure;
+            }
+
+            _settings.lora.backend = std::string(args.at(++i));
+            if (!is_supported_lora_backend(_settings.lora.backend)) {
+                std::cerr << "Unsupported LoRa backend: " << _settings.lora.backend << '\n';
+                usage(args.program_name());
+                return ParseStatus::ExitFailure;
+            }
+            continue;
+        }
+
         std::cerr << "Unknown option: " << arg << '\n';
         usage(args.program_name());
         return ParseStatus::ExitFailure;
@@ -106,6 +126,7 @@ void cli::Config::usage(std::string_view program_name) const {
               << "  -h, --help            Show this help message and exit\n"
               << "  -c, --config <file>   Path to configuration file\n"
               << "  -m, --lora-module <name>  LoRa module (sx1262 or sx127)\n"
+              << "  -b, --lora-backend <name> LoRa backend (virtual or hardware)\n"
               << "  -v, --verbose         Enable verbose output" << std::endl;
 }
 
@@ -177,6 +198,11 @@ bool cli::Config::parse_config_file(std::string &error_message) {
 
             if (!parse_optional_value(lora_node, "module", _settings.lora.module, error_message))
                 return false;
+            if (!parse_optional_value(lora_node,
+                                      "backend",
+                                      _settings.lora.backend,
+                                      error_message))
+                return false;
         }
 
         if (_settings.sdr.sample_rate_hz <= 0) {
@@ -193,6 +219,10 @@ bool cli::Config::parse_config_file(std::string &error_message) {
         }
         if (!is_supported_lora_module(_settings.lora.module)) {
             error_message = "lora.module must be one of: sx1262, sx127.";
+            return false;
+        }
+        if (!is_supported_lora_backend(_settings.lora.backend)) {
+            error_message = "lora.backend must be one of: virtual, hardware.";
             return false;
         }
     } catch (const YAML::BadFile &e) {

--- a/LoRa/src/connector/local_tcp_transport.cc
+++ b/LoRa/src/connector/local_tcp_transport.cc
@@ -8,6 +8,7 @@
 #include "connector/local_tcp_transport.h"
 
 #include <chrono>
+#include <cerrno>
 #include <cstring>
 #include <stdexcept>
 #include <thread>
@@ -21,7 +22,9 @@
     #pragma comment(lib, "Ws2_32.lib")
 #else
     #include <arpa/inet.h>
+    #include <fcntl.h>
     #include <netdb.h>
+    #include <sys/select.h>
     #include <sys/socket.h>
     #include <unistd.h>
 #endif
@@ -35,6 +38,53 @@ namespace {
     void close_socket(NativeSocket socket_handle) {
         if (socket_handle != invalid_socket_value)
             ::closesocket(socket_handle);
+    }
+
+    bool set_nonblocking(NativeSocket socket_handle, bool nonblocking) {
+        u_long mode = nonblocking ? 1UL : 0UL;
+        return ::ioctlsocket(socket_handle, FIONBIO, &mode) == 0;
+    }
+
+    bool connect_in_progress_error() {
+        const int error = ::WSAGetLastError();
+        return error == WSAEWOULDBLOCK || error == WSAEINPROGRESS || error == WSAEALREADY;
+    }
+
+    bool connect_with_timeout(NativeSocket socket_handle,
+                              const sockaddr_in &address,
+                              int timeout_ms) {
+        if (::connect(socket_handle,
+                      reinterpret_cast<const sockaddr *>(&address),
+                      static_cast<int>(sizeof(address))) == 0) {
+            return true;
+        }
+
+        if (!connect_in_progress_error())
+            return false;
+
+        fd_set write_fds;
+        FD_ZERO(&write_fds);
+        FD_SET(socket_handle, &write_fds);
+
+        timeval timeout {};
+        timeout.tv_sec = timeout_ms / 1000;
+        timeout.tv_usec = (timeout_ms % 1000) * 1000;
+
+        const int ready = ::select(0, nullptr, &write_fds, nullptr, &timeout);
+        if (ready <= 0)
+            return false;
+
+        int socket_error = 0;
+        int socket_error_len = static_cast<int>(sizeof(socket_error));
+        if (::getsockopt(socket_handle,
+                         SOL_SOCKET,
+                         SO_ERROR,
+                         reinterpret_cast<char *>(&socket_error),
+                         &socket_error_len) != 0) {
+            return false;
+        }
+
+        return socket_error == 0;
     }
 
     // Initialize Winsock once per process.
@@ -57,6 +107,56 @@ namespace {
     void close_socket(NativeSocket socket_handle) {
         if (socket_handle != invalid_socket_value)
             ::close(socket_handle);
+    }
+
+    bool set_nonblocking(NativeSocket socket_handle, bool nonblocking) {
+        const int flags = ::fcntl(socket_handle, F_GETFL, 0);
+        if (flags < 0)
+            return false;
+
+        const int updated_flags = nonblocking ? (flags | O_NONBLOCK) : (flags & ~O_NONBLOCK);
+        return ::fcntl(socket_handle, F_SETFL, updated_flags) == 0;
+    }
+
+    bool connect_in_progress_error() {
+        return errno == EINPROGRESS || errno == EWOULDBLOCK;
+    }
+
+    bool connect_with_timeout(NativeSocket socket_handle,
+                              const sockaddr_in &address,
+                              int timeout_ms) {
+        if (::connect(socket_handle,
+                      reinterpret_cast<const sockaddr *>(&address),
+                      static_cast<int>(sizeof(address))) == 0) {
+            return true;
+        }
+
+        if (!connect_in_progress_error())
+            return false;
+
+        fd_set write_fds;
+        FD_ZERO(&write_fds);
+        FD_SET(socket_handle, &write_fds);
+
+        timeval timeout {};
+        timeout.tv_sec = timeout_ms / 1000;
+        timeout.tv_usec = (timeout_ms % 1000) * 1000;
+
+        const int ready = ::select(socket_handle + 1, nullptr, &write_fds, nullptr, &timeout);
+        if (ready <= 0)
+            return false;
+
+        int socket_error = 0;
+        socklen_t socket_error_len = sizeof(socket_error);
+        if (::getsockopt(socket_handle,
+                         SOL_SOCKET,
+                         SO_ERROR,
+                         reinterpret_cast<char *>(&socket_error),
+                         &socket_error_len) != 0) {
+            return false;
+        }
+
+        return socket_error == 0;
     }
 #endif
 
@@ -134,17 +234,25 @@ void connector::LocalTcpTransport::open() {
         if (_socket == invalid_socket_value)
             throw std::runtime_error("Failed to create client socket.");
 
-        for (int attempt = 0; attempt < 50; ++attempt) {
-            if (::connect(_socket,
-                          reinterpret_cast<const sockaddr *>(&address),
-                          static_cast<int>(sizeof(address))) == 0) {
+        if (!set_nonblocking(_socket, true)) {
+            close();
+            throw std::runtime_error("Failed to configure non-blocking client socket.");
+        }
+
+        for (int attempt = 0; attempt < 20; ++attempt) {
+            if (connect_with_timeout(_socket, address, 150)) {
                 break;
             }
-            if (attempt == 49) {
+            if (attempt == 19) {
                 close();
                 throw std::runtime_error("Failed to connect local TCP transport.");
             }
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+
+        if (!set_nonblocking(_socket, false)) {
+            close();
+            throw std::runtime_error("Failed to restore blocking mode on client socket.");
         }
     }
 

--- a/LoRa/src/connector/local_udp_transport.cc
+++ b/LoRa/src/connector/local_udp_transport.cc
@@ -1,0 +1,220 @@
+/**
+ * @file local_udp_transport.cc
+ * @brief Local UDP transport for connector messages
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#include "connector/local_udp_transport.h"
+
+#include <array>
+#include <cstring>
+#include <stdexcept>
+#include <utility>
+
+#ifdef _WIN32
+    #ifndef WIN32_LEAN_AND_MEAN
+        #define WIN32_LEAN_AND_MEAN
+    #endif
+    #include <winsock2.h>
+    #include <ws2tcpip.h>
+    #pragma comment(lib, "Ws2_32.lib")
+#else
+    #include <arpa/inet.h>
+    #include <sys/select.h>
+    #include <sys/socket.h>
+    #include <unistd.h>
+#endif
+
+namespace {
+#ifdef _WIN32
+    using NativeSocket = SOCKET;
+    constexpr NativeSocket invalid_socket_value = INVALID_SOCKET;
+
+    void close_socket(NativeSocket socket_handle) {
+        if (socket_handle != invalid_socket_value)
+            ::closesocket(socket_handle);
+    }
+
+    void ensure_winsock_started() {
+        static bool initialized = false;
+        if (initialized)
+            return;
+
+        WSADATA data {};
+        const int result = ::WSAStartup(MAKEWORD(2, 2), &data);
+        if (result != 0)
+            throw std::runtime_error("WSAStartup failed.");
+        initialized = true;
+    }
+#else
+    using NativeSocket = int;
+    constexpr NativeSocket invalid_socket_value = -1;
+
+    void close_socket(NativeSocket socket_handle) {
+        if (socket_handle != invalid_socket_value)
+            ::close(socket_handle);
+    }
+#endif
+
+    sockaddr_in make_address(const std::string &host, std::uint16_t port) {
+        sockaddr_in address {};
+        address.sin_family = AF_INET;
+        address.sin_port = htons(port);
+
+        if (host.empty() || host == "127.0.0.1" || host == "localhost") {
+            address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+            return address;
+        }
+
+        if (::inet_pton(AF_INET, host.c_str(), &address.sin_addr) != 1)
+            throw std::runtime_error("Invalid IPv4 host: " + host);
+
+        return address;
+    }
+}
+
+connector::LocalUdpTransport::LocalUdpTransport(LocalUdpMode mode,
+                                                std::string host,
+                                                std::uint16_t port)
+    : _mode(mode), _host(std::move(host)), _port(port) {}
+
+connector::LocalUdpTransport::~LocalUdpTransport() {
+    close();
+}
+
+void connector::LocalUdpTransport::open() {
+    if (_is_open)
+        return;
+
+#ifdef _WIN32
+    ensure_winsock_started();
+#endif
+
+    _socket = ::socket(AF_INET, SOCK_DGRAM, 0);
+    if (_socket == invalid_socket_value)
+        throw std::runtime_error("Failed to create UDP socket.");
+
+    const sockaddr_in address = make_address(_host, _port);
+
+    if (_mode == LocalUdpMode::Server) {
+        int reuse_enabled = 1;
+        ::setsockopt(_socket,
+                     SOL_SOCKET,
+                     SO_REUSEADDR,
+                     reinterpret_cast<const char *>(&reuse_enabled),
+                     static_cast<int>(sizeof(reuse_enabled)));
+
+        if (::bind(_socket,
+                   reinterpret_cast<const sockaddr *>(&address),
+                   static_cast<int>(sizeof(address))) != 0) {
+            close();
+            throw std::runtime_error("Failed to bind local UDP transport.");
+        }
+    } else {
+        if (::connect(_socket,
+                      reinterpret_cast<const sockaddr *>(&address),
+                      static_cast<int>(sizeof(address))) != 0) {
+            close();
+            throw std::runtime_error("Failed to connect local UDP transport.");
+        }
+        _has_peer = true;
+        _peer_ip = _host.empty() ? "127.0.0.1" : _host;
+        _peer_port = _port;
+    }
+
+    _is_open = true;
+}
+
+void connector::LocalUdpTransport::close() noexcept {
+    if (_socket != invalid_socket_value) {
+        close_socket(_socket);
+        _socket = invalid_socket_value;
+    }
+    _is_open = false;
+    _has_peer = false;
+    _peer_ip.clear();
+    _peer_port = 0;
+}
+
+void connector::LocalUdpTransport::ensure_open() const {
+    if (!_is_open || _socket == invalid_socket_value)
+        throw std::runtime_error("Local UDP transport is not open.");
+}
+
+void connector::LocalUdpTransport::write_datagram(const std::string &payload) {
+    ensure_open();
+
+    if (_mode == LocalUdpMode::Client) {
+        const int sent = static_cast<int>(::send(_socket, payload.data(), payload.size(), 0));
+        if (sent < 0 || static_cast<std::size_t>(sent) != payload.size())
+            throw std::runtime_error("Failed to send UDP datagram.");
+        return;
+    }
+
+    if (!_has_peer)
+        throw std::runtime_error("Cannot send UDP datagram before a client peer is known.");
+
+    const sockaddr_in peer = make_address(_peer_ip, _peer_port);
+    const int sent = static_cast<int>(::sendto(_socket,
+                                               payload.data(),
+                                               payload.size(),
+                                               0,
+                                               reinterpret_cast<const sockaddr *>(&peer),
+                                               static_cast<int>(sizeof(peer))));
+    if (sent < 0 || static_cast<std::size_t>(sent) != payload.size())
+        throw std::runtime_error("Failed to send UDP datagram.");
+}
+
+bool connector::LocalUdpTransport::read_datagram(std::string &payload, std::uint32_t timeout_ms) {
+    ensure_open();
+
+    fd_set read_set;
+    FD_ZERO(&read_set);
+    FD_SET(_socket, &read_set);
+
+    timeval timeout {};
+    timeout.tv_sec = static_cast<long>(timeout_ms / 1000U);
+    timeout.tv_usec = static_cast<long>((timeout_ms % 1000U) * 1000U);
+
+#ifdef _WIN32
+    const int select_result = ::select(0, &read_set, nullptr, nullptr, &timeout);
+#else
+    const int select_result = ::select(_socket + 1, &read_set, nullptr, nullptr, &timeout);
+#endif
+    if (select_result < 0)
+        throw std::runtime_error("Failed waiting on UDP socket.");
+    if (select_result == 0)
+        return false;
+
+    std::array<char, 65535> buffer {};
+    sockaddr_in peer_address {};
+#ifdef _WIN32
+    int peer_len = static_cast<int>(sizeof(peer_address));
+#else
+    socklen_t peer_len = static_cast<socklen_t>(sizeof(peer_address));
+#endif
+
+    const int received = static_cast<int>(::recvfrom(_socket,
+                                                     buffer.data(),
+                                                     static_cast<int>(buffer.size()),
+                                                     0,
+                                                     reinterpret_cast<sockaddr *>(&peer_address),
+                                                     &peer_len));
+    if (received < 0)
+        throw std::runtime_error("Failed to receive UDP datagram.");
+
+    payload.assign(buffer.data(), buffer.data() + received);
+
+    // Learn the last peer in server mode so replies can be sent back.
+    if (_mode == LocalUdpMode::Server) {
+        char ip_buffer[INET_ADDRSTRLEN] {};
+        if (::inet_ntop(AF_INET, &peer_address.sin_addr, ip_buffer, INET_ADDRSTRLEN) != nullptr) {
+            _peer_ip = ip_buffer;
+            _peer_port = ntohs(peer_address.sin_port);
+            _has_peer = true;
+        }
+    }
+
+    return true;
+}

--- a/LoRa/src/connector/local_zmq_transport.cc
+++ b/LoRa/src/connector/local_zmq_transport.cc
@@ -1,0 +1,166 @@
+/**
+ * @file local_zmq_transport.cc
+ * @brief Optional local ZeroMQ transport for connector messages
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#include "connector/local_zmq_transport.h"
+
+#include <stdexcept>
+#include <utility>
+
+#if defined(LBR_HAS_ZEROMQ) && LBR_HAS_ZEROMQ
+    #include <zmq.h>
+#endif
+
+namespace connector {
+    struct LocalZmqTransport::Impl {
+#if defined(LBR_HAS_ZEROMQ) && LBR_HAS_ZEROMQ
+        void *context = nullptr;
+        void *socket = nullptr;
+#endif
+    };
+}
+
+connector::LocalZmqTransport::LocalZmqTransport(LocalZmqMode mode,
+                                                std::string endpoint,
+                                                std::string topic)
+    : _mode(mode),
+      _endpoint(std::move(endpoint)),
+      _topic(std::move(topic)),
+      _impl(new Impl()) {}
+
+connector::LocalZmqTransport::~LocalZmqTransport() {
+    close();
+    delete _impl;
+    _impl = nullptr;
+}
+
+void connector::LocalZmqTransport::open() {
+    if (_is_open)
+        return;
+
+#if defined(LBR_HAS_ZEROMQ) && LBR_HAS_ZEROMQ
+    _impl->context = ::zmq_ctx_new();
+    if (_impl->context == nullptr)
+        throw std::runtime_error("Failed to create ZeroMQ context.");
+
+    const int socket_type = _mode == LocalZmqMode::Publisher ? ZMQ_PUB : ZMQ_SUB;
+    _impl->socket = ::zmq_socket(_impl->context, socket_type);
+    if (_impl->socket == nullptr) {
+        close();
+        throw std::runtime_error("Failed to create ZeroMQ socket.");
+    }
+
+    if (_mode == LocalZmqMode::Publisher) {
+        if (::zmq_bind(_impl->socket, _endpoint.c_str()) != 0) {
+            close();
+            throw std::runtime_error("Failed to bind ZeroMQ publisher socket.");
+        }
+    } else {
+        if (::zmq_connect(_impl->socket, _endpoint.c_str()) != 0) {
+            close();
+            throw std::runtime_error("Failed to connect ZeroMQ subscriber socket.");
+        }
+        if (::zmq_setsockopt(_impl->socket,
+                             ZMQ_SUBSCRIBE,
+                             _topic.data(),
+                             static_cast<int>(_topic.size())) != 0) {
+            close();
+            throw std::runtime_error("Failed to subscribe ZeroMQ topic.");
+        }
+    }
+
+    _is_open = true;
+#else
+    (void)_endpoint;
+    (void)_topic;
+    throw std::runtime_error("ZeroMQ support is not enabled in this build.");
+#endif
+}
+
+void connector::LocalZmqTransport::close() noexcept {
+#if defined(LBR_HAS_ZEROMQ) && LBR_HAS_ZEROMQ
+    if (_impl != nullptr && _impl->socket != nullptr) {
+        ::zmq_close(_impl->socket);
+        _impl->socket = nullptr;
+    }
+
+    if (_impl != nullptr && _impl->context != nullptr) {
+        ::zmq_ctx_term(_impl->context);
+        _impl->context = nullptr;
+    }
+#endif
+    _is_open = false;
+}
+
+void connector::LocalZmqTransport::ensure_open() const {
+    if (!_is_open)
+        throw std::runtime_error("Local ZeroMQ transport is not open.");
+}
+
+void connector::LocalZmqTransport::send_message(const std::string &payload) {
+    ensure_open();
+
+#if defined(LBR_HAS_ZEROMQ) && LBR_HAS_ZEROMQ
+    if (_mode != LocalZmqMode::Publisher)
+        throw std::runtime_error("Only ZeroMQ publisher can send messages.");
+
+    const int sent_topic =
+        static_cast<int>(::zmq_send(_impl->socket, _topic.data(), _topic.size(), ZMQ_SNDMORE));
+    if (sent_topic < 0)
+        throw std::runtime_error("Failed to send ZeroMQ topic frame.");
+
+    const int sent_payload =
+        static_cast<int>(::zmq_send(_impl->socket, payload.data(), payload.size(), 0));
+    if (sent_payload < 0)
+        throw std::runtime_error("Failed to send ZeroMQ payload frame.");
+#else
+    (void)payload;
+    throw std::runtime_error("ZeroMQ support is not enabled in this build.");
+#endif
+}
+
+bool connector::LocalZmqTransport::receive_message(std::string &payload, std::int32_t timeout_ms) {
+    ensure_open();
+
+#if defined(LBR_HAS_ZEROMQ) && LBR_HAS_ZEROMQ
+    if (_mode != LocalZmqMode::Subscriber)
+        throw std::runtime_error("Only ZeroMQ subscriber can receive messages.");
+
+    if (::zmq_setsockopt(_impl->socket, ZMQ_RCVTIMEO, &timeout_ms, sizeof(timeout_ms)) != 0)
+        throw std::runtime_error("Failed to configure ZeroMQ receive timeout.");
+
+    zmq_msg_t topic_frame;
+    if (::zmq_msg_init(&topic_frame) != 0)
+        throw std::runtime_error("Failed to initialize ZeroMQ topic frame.");
+
+    const int topic_result = ::zmq_msg_recv(&topic_frame, _impl->socket, 0);
+    if (topic_result < 0) {
+        ::zmq_msg_close(&topic_frame);
+        return false;
+    }
+
+    ::zmq_msg_close(&topic_frame);
+
+    zmq_msg_t payload_frame;
+    if (::zmq_msg_init(&payload_frame) != 0)
+        throw std::runtime_error("Failed to initialize ZeroMQ payload frame.");
+
+    const int payload_result = ::zmq_msg_recv(&payload_frame, _impl->socket, 0);
+    if (payload_result < 0) {
+        ::zmq_msg_close(&payload_frame);
+        return false;
+    }
+
+    payload.assign(static_cast<const char *>(::zmq_msg_data(&payload_frame)),
+                   static_cast<std::size_t>(::zmq_msg_size(&payload_frame)));
+    ::zmq_msg_close(&payload_frame);
+    return true;
+#else
+    (void)payload;
+    (void)timeout_ms;
+    throw std::runtime_error("ZeroMQ support is not enabled in this build.");
+#endif
+}

--- a/LoRa/src/connector/message.cc
+++ b/LoRa/src/connector/message.cc
@@ -7,18 +7,14 @@
 
 #include "connector/message.h"
 
-#include <algorithm>
 #include <cctype>
 #include <iomanip>
-#include <regex>
 #include <sstream>
 #include <stdexcept>
 
-namespace {
-    std::string field_prefix(const std::string &field_name) {
-        return std::string("\"") + field_name + "\"\\s*:\\s*";
-    }
+#include <yaml-cpp/yaml.h>
 
+namespace {
     std::string escape_json_string(const std::string &input) {
         std::ostringstream output;
         output << '"';
@@ -115,105 +111,19 @@ namespace {
         return output;
     }
 
-    std::string read_string_field(const std::string &json_text, const std::string &field_name) {
-        const std::regex pattern(field_prefix(field_name) + R"REGEX("((?:\\.|[^"])*)")REGEX");
-        std::smatch match;
-        if (!std::regex_search(json_text, match, pattern) || match.size() < 2)
-            throw std::runtime_error("Missing string field: " + field_name);
-        return match[1].str();
-    }
+    template <typename T>
+    T read_required_scalar(const YAML::Node &root, const char *field_name) {
+        const YAML::Node node = root[field_name];
+        if (!node)
+            throw std::runtime_error(std::string("Missing field: ") + field_name);
+        if (!node.IsScalar())
+            throw std::runtime_error(std::string("Field must be scalar: ") + field_name);
 
-    std::string unescape_json_string(const std::string &input) {
-        std::string output;
-        output.reserve(input.size());
-        for (std::size_t index = 0; index < input.size(); ++index) {
-            const char character = input[index];
-            if (character != '\\') {
-                output.push_back(character);
-                continue;
-            }
-
-            if (index + 1 >= input.size())
-                throw std::runtime_error("Invalid escape sequence in JSON string.");
-
-            const char escaped = input[++index];
-            switch (escaped) {
-                case '\\': output.push_back('\\'); break;
-                case '"': output.push_back('"'); break;
-                case 'b': output.push_back('\b'); break;
-                case 'f': output.push_back('\f'); break;
-                case 'n': output.push_back('\n'); break;
-                case 'r': output.push_back('\r'); break;
-                case 't': output.push_back('\t'); break;
-                case 'u':
-                    throw std::runtime_error("Unicode escapes are not supported in connector JSON.");
-                default:
-                    throw std::runtime_error("Unknown escape sequence in JSON string.");
-            }
+        try {
+            return node.as<T>();
+        } catch (const YAML::Exception &e) {
+            throw std::runtime_error(std::string("Invalid field '") + field_name + "': " + e.what());
         }
-        return output;
-    }
-
-    std::string read_optional_string_field(const std::string &json_text,
-                                           const std::string &field_name) {
-        const std::regex pattern(field_prefix(field_name) + R"REGEX("((?:\\.|[^"])*)")REGEX");
-        std::smatch match;
-        if (!std::regex_search(json_text, match, pattern) || match.size() < 2)
-            return {};
-        return unescape_json_string(match[1].str());
-    }
-
-    std::uint64_t read_uint64_field(const std::string &json_text, const std::string &field_name) {
-        const std::regex pattern(field_prefix(field_name) + R"(([0-9]+))");
-        std::smatch match;
-        if (!std::regex_search(json_text, match, pattern) || match.size() < 2)
-            throw std::runtime_error("Missing integer field: " + field_name);
-        return static_cast<std::uint64_t>(std::stoull(match[1].str()));
-    }
-
-    std::int64_t read_int64_field(const std::string &json_text, const std::string &field_name) {
-        const std::regex pattern(field_prefix(field_name) + R"((-?[0-9]+))");
-        std::smatch match;
-        if (!std::regex_search(json_text, match, pattern) || match.size() < 2)
-            throw std::runtime_error("Missing integer field: " + field_name);
-        return static_cast<std::int64_t>(std::stoll(match[1].str()));
-    }
-
-    std::string extract_object_text(const std::string &json_text, const std::string &field_name) {
-        const std::string key = '"' + field_name + '"';
-        const std::size_t key_position = json_text.find(key);
-        if (key_position == std::string::npos)
-            return {};
-
-        const std::size_t brace_position = json_text.find('{', key_position + key.size());
-        if (brace_position == std::string::npos)
-            throw std::runtime_error("Malformed object field: " + field_name);
-
-        int depth = 0;
-        for (std::size_t index = brace_position; index < json_text.size(); ++index) {
-            if (json_text[index] == '{')
-                ++depth;
-            else if (json_text[index] == '}') {
-                --depth;
-                if (depth == 0)
-                    return json_text.substr(brace_position + 1, index - brace_position - 1);
-            }
-        }
-
-        throw std::runtime_error("Unterminated object field: " + field_name);
-    }
-
-    std::map<std::string, std::string> parse_metadata_object(const std::string &json_text) {
-        std::map<std::string, std::string> metadata;
-        if (json_text.empty())
-            return metadata;
-
-        const std::regex pattern(R"REGEX("((?:\\.|[^"])*)"\s*:\s*"((?:\\.|[^"])*)")REGEX");
-        for (std::sregex_iterator it(json_text.begin(), json_text.end(), pattern), end; it != end;
-             ++it) {
-            metadata.emplace(unescape_json_string((*it)[1].str()), unescape_json_string((*it)[2].str()));
-        }
-        return metadata;
     }
 }
 
@@ -275,30 +185,54 @@ std::string connector::ConnectorMessage::to_json() const {
 }
 
 connector::ConnectorMessage connector::ConnectorMessage::from_json(const std::string &json_text) {
+    YAML::Node root;
+    try {
+        root = YAML::Load(json_text);
+    } catch (const YAML::Exception &e) {
+        throw std::runtime_error(std::string("Malformed connector JSON: ") + e.what());
+    }
+
+    if (!root || !root.IsMap())
+        throw std::runtime_error("Connector JSON root must be an object.");
+
     ConnectorMessage message;
-    message.schema_version = static_cast<int>(read_uint64_field(json_text, "schema_version"));
+    message.schema_version = static_cast<int>(read_required_scalar<std::uint64_t>(root, "schema_version"));
     if (message.schema_version < 1)
         throw std::runtime_error("schema_version must be >= 1.");
 
-    message.message_type = read_string_field(json_text, "message_type");
+    message.message_type = read_required_scalar<std::string>(root, "message_type");
     if (message.message_type.empty())
         throw std::runtime_error("message_type must not be empty.");
 
-    message.sequence = read_uint64_field(json_text, "sequence");
-    message.timestamp_ms = read_int64_field(json_text, "timestamp_ms");
-    message.source = read_string_field(json_text, "source");
+    message.sequence = read_required_scalar<std::uint64_t>(root, "sequence");
+    message.timestamp_ms = read_required_scalar<std::int64_t>(root, "timestamp_ms");
+    message.source = read_required_scalar<std::string>(root, "source");
     if (message.source.empty())
         throw std::runtime_error("source must not be empty.");
 
-    message.payload = base64_decode(read_string_field(json_text, "payload_b64"));
+    message.payload = base64_decode(read_required_scalar<std::string>(root, "payload_b64"));
 
-    const std::string checksum = read_optional_string_field(json_text, "checksum_hex");
-    if (!checksum.empty())
-        message.checksum_hex = checksum;
+    const YAML::Node checksum_node = root["checksum_hex"];
+    if (checksum_node) {
+        if (!checksum_node.IsScalar())
+            throw std::runtime_error("checksum_hex must be a string.");
+        const std::string checksum = checksum_node.as<std::string>();
+        if (!checksum.empty())
+            message.checksum_hex = checksum;
+    }
 
-    const std::string metadata_text = extract_object_text(json_text, "metadata");
-    if (!metadata_text.empty())
-        message.metadata = parse_metadata_object(metadata_text);
+    const YAML::Node metadata_node = root["metadata"];
+    if (metadata_node) {
+        if (!metadata_node.IsMap())
+            throw std::runtime_error("metadata must be an object.");
+
+        for (const auto &entry : metadata_node) {
+            if (!entry.first.IsScalar() || !entry.second.IsScalar())
+                throw std::runtime_error("metadata keys and values must be strings.");
+
+            message.metadata.emplace(entry.first.as<std::string>(), entry.second.as<std::string>());
+        }
+    }
 
     return message;
 }

--- a/LoRa/src/connector/message.cc
+++ b/LoRa/src/connector/message.cc
@@ -239,10 +239,12 @@ connector::Source connector::source_from_string(std::string_view source_name) {
 }
 
 std::string connector::ConnectorMessage::to_json() const {
-    if (schema_version != 1)
-        throw std::runtime_error("Unsupported connector schema version.");
-    if (message_type != "telemetry_frame")
-        throw std::runtime_error("Unsupported connector message type.");
+    if (schema_version < 1)
+        throw std::runtime_error("schema_version must be >= 1.");
+    if (message_type.empty())
+        throw std::runtime_error("message_type must not be empty.");
+    if (source.empty())
+        throw std::runtime_error("source must not be empty.");
 
     std::ostringstream output;
     output << '{'
@@ -250,7 +252,7 @@ std::string connector::ConnectorMessage::to_json() const {
            << "\"message_type\":" << escape_json_string(message_type) << ','
            << "\"sequence\":" << sequence << ','
            << "\"timestamp_ms\":" << timestamp_ms << ','
-           << "\"source\":" << escape_json_string(source_to_string(source)) << ','
+           << "\"source\":" << escape_json_string(source) << ','
            << "\"payload_b64\":" << escape_json_string(base64_encode(payload));
 
     if (checksum_hex.has_value())
@@ -275,10 +277,19 @@ std::string connector::ConnectorMessage::to_json() const {
 connector::ConnectorMessage connector::ConnectorMessage::from_json(const std::string &json_text) {
     ConnectorMessage message;
     message.schema_version = static_cast<int>(read_uint64_field(json_text, "schema_version"));
+    if (message.schema_version < 1)
+        throw std::runtime_error("schema_version must be >= 1.");
+
     message.message_type = read_string_field(json_text, "message_type");
+    if (message.message_type.empty())
+        throw std::runtime_error("message_type must not be empty.");
+
     message.sequence = read_uint64_field(json_text, "sequence");
     message.timestamp_ms = read_int64_field(json_text, "timestamp_ms");
-    message.source = source_from_string(read_string_field(json_text, "source"));
+    message.source = read_string_field(json_text, "source");
+    if (message.source.empty())
+        throw std::runtime_error("source must not be empty.");
+
     message.payload = base64_decode(read_string_field(json_text, "payload_b64"));
 
     const std::string checksum = read_optional_string_field(json_text, "checksum_hex");

--- a/LoRa/src/hil_runner.cc
+++ b/LoRa/src/hil_runner.cc
@@ -1,6 +1,6 @@
 /**
  * @file hil_runner.cc
- * @brief Hardware-in-the-loop runner for real LoRa backend validation
+ * @brief Hardware-in-the-loop runner for real LoRa module validation
  */
 
 #include "periph/i_lora_module.h"

--- a/LoRa/src/hil_runner.cc
+++ b/LoRa/src/hil_runner.cc
@@ -1,0 +1,91 @@
+/**
+ * @file hil_runner.cc
+ * @brief Hardware-in-the-loop runner for real LoRa backend validation
+ */
+
+#include "periph/i_lora_module.h"
+#include "periph/sx1262_module.h"
+#include "periph/sx127_module.h"
+
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace {
+    std::unique_ptr<periph::ILoRaModule> create_lora_module(const std::string &module_name) {
+        if (module_name == "sx127")
+            return std::make_unique<periph::SX127Module>();
+        return std::make_unique<periph::SX1262Module>();
+    }
+
+    void usage(const char *program) {
+        std::cout << "Usage: " << program << " [--module sx1262|sx127] [--timeout-ms N] [--min-bytes N]\n";
+    }
+}
+
+int main(int argc, char **argv) {
+    std::string module_name = "sx1262";
+    std::uint32_t timeout_ms = 3000;
+    std::size_t min_bytes = 1;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--help") {
+            usage(argv[0]);
+            return 0;
+        }
+        if (arg == "--module" && i + 1 < argc) {
+            module_name = argv[++i];
+            continue;
+        }
+        if (arg == "--timeout-ms" && i + 1 < argc) {
+            timeout_ms = static_cast<std::uint32_t>(std::stoul(argv[++i]));
+            continue;
+        }
+        if (arg == "--min-bytes" && i + 1 < argc) {
+            min_bytes = static_cast<std::size_t>(std::stoull(argv[++i]));
+            continue;
+        }
+
+        std::cerr << "Unknown or incomplete argument: " << arg << '\n';
+        usage(argv[0]);
+        return 2;
+    }
+
+    if (module_name != "sx1262" && module_name != "sx127") {
+        std::cerr << "Unsupported module: " << module_name << '\n';
+        return 2;
+    }
+
+    std::unique_ptr<periph::ILoRaModule> module = create_lora_module(module_name);
+    const periph::LoRaStatusCode init_status = module->init();
+    if (init_status != periph::LoRaStatusCode::Ok) {
+        std::cerr << "HIL init failed for module=" << module_name << '\n';
+        return 1;
+    }
+
+    std::uint8_t buffer[512] {};
+    const auto start = std::chrono::steady_clock::now();
+
+    while (true) {
+        const periph::LoRaReceiveResult rx = module->receive(buffer, sizeof(buffer), 100);
+        if (rx.status == periph::LoRaStatusCode::Ok && rx.bytes_received >= min_bytes) {
+            std::cout << "HIL PASS module=" << module_name
+                      << " bytes_received=" << rx.bytes_received
+                      << " rssi_dbm=" << rx.signal.rssi_dbm
+                      << " snr_db=" << rx.signal.snr_db << '\n';
+            return 0;
+        }
+
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start);
+        if (elapsed.count() >= static_cast<long long>(timeout_ms)) {
+            std::cerr << "HIL FAIL module=" << module_name
+                      << " timeout_ms=" << timeout_ms
+                      << " last_status=" << static_cast<int>(rx.status) << '\n';
+            return 1;
+        }
+    }
+}

--- a/LoRa/src/main.cc
+++ b/LoRa/src/main.cc
@@ -28,9 +28,9 @@
 
 namespace {
     std::unique_ptr<periph::ILoRaModule> create_lora_module(const cli::LoRaSettings &settings) {
-        if (settings.backend == "hardware") {
+        if (settings.mode == "hardware") {
             throw std::runtime_error(
-                "Hardware LoRa backend is not implemented yet; use lora.backend=virtual.");
+            "Hardware LoRa mode is not implemented yet; use lora.mode=virtual.");
         }
 
         const std::string &module_name = settings.module;

--- a/LoRa/src/main.cc
+++ b/LoRa/src/main.cc
@@ -62,7 +62,7 @@ int main(int argc, char * const argv[]) {
 
     std::unique_ptr<periph::ILoRaModule> lora_module =
         create_lora_module(config.settings().lora.module);
-    SDRPipeline pipeline(config.settings(), lora_module.get());
+    SDRPipeline pipeline(config.settings(), *lora_module);
 
     try {
         pipeline.run();

--- a/LoRa/src/main.cc
+++ b/LoRa/src/main.cc
@@ -24,9 +24,16 @@
 #include <exception>
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 
 namespace {
-    std::unique_ptr<periph::ILoRaModule> create_lora_module(const std::string &module_name) {
+    std::unique_ptr<periph::ILoRaModule> create_lora_module(const cli::LoRaSettings &settings) {
+        if (settings.backend == "hardware") {
+            throw std::runtime_error(
+                "Hardware LoRa backend is not implemented yet; use lora.backend=virtual.");
+        }
+
+        const std::string &module_name = settings.module;
         if (module_name == "sx127")
             return std::make_unique<periph::SX127Module>();
 
@@ -60,11 +67,10 @@ int main(int argc, char * const argv[]) {
             break;
     }
 
-    std::unique_ptr<periph::ILoRaModule> lora_module =
-        create_lora_module(config.settings().lora.module);
-    SDRPipeline pipeline(config.settings(), *lora_module);
-
     try {
+        std::unique_ptr<periph::ILoRaModule> lora_module =
+            create_lora_module(config.settings().lora);
+        SDRPipeline pipeline(config.settings(), *lora_module);
         pipeline.run();
     } catch (const std::exception &e) {
         std::cerr << "Error: " << e.what() << std::endl;

--- a/LoRa/src/periph/sx1262_module.cc
+++ b/LoRa/src/periph/sx1262_module.cc
@@ -8,10 +8,14 @@
 #include "periph/sx1262_module.h"
 
 periph::LoRaStatusCode periph::SX1262Module::init() {
+    _initialized = true;
     return periph::LoRaStatusCode::Ok;
 }
 
 periph::LoRaTransmitResult periph::SX1262Module::transmit(const uint8_t *buf, size_t len) {
+    if (!_initialized)
+        return {periph::LoRaStatusCode::NotInitialized, 0};
+
     if (buf == nullptr && len > 0)
         return {periph::LoRaStatusCode::InvalidArgument, 0};
 
@@ -21,6 +25,9 @@ periph::LoRaTransmitResult periph::SX1262Module::transmit(const uint8_t *buf, si
 
 periph::LoRaReceiveResult periph::SX1262Module::receive(uint8_t *buf, size_t max_len,
                                                         uint32_t /*timeout_ms*/) {
+    if (!_initialized)
+        return {periph::LoRaStatusCode::NotInitialized, 0, {}};
+
     if (buf == nullptr && max_len > 0)
         return {periph::LoRaStatusCode::InvalidArgument, 0, {}};
 

--- a/LoRa/src/periph/sx1262_module.cc
+++ b/LoRa/src/periph/sx1262_module.cc
@@ -1,14 +1,42 @@
 /**
  * @file sx1262_module.cc
- * @brief Skeleton SX1262 LoRa backend implementation
+ * @brief Virtual SX1262 LoRa backend implementation
  * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
  * @note Origin: Long Beach Rocketry
  */
 
 #include "periph/sx1262_module.h"
 
+#include <array>
+#include <algorithm>
+
+namespace {
+    constexpr std::array<std::uint8_t, 6> default_frame{{2U, 0x10U, 0x00U, 0xF4U, 0x01U, 87U}};
+    const periph::LoRaSignalMetrics default_signal{true, -84, 7.5F};
+
+    periph::LoRaReceiveResult copy_frame(uint8_t *buf,
+                                         size_t max_len,
+                                         const std::vector<std::uint8_t> &frame,
+                                         const periph::LoRaSignalMetrics &signal) {
+        if (buf == nullptr && max_len > 0)
+            return {periph::LoRaStatusCode::InvalidArgument, 0, {}};
+
+        if (max_len < frame.size())
+            return {periph::LoRaStatusCode::InvalidArgument, 0, {}};
+
+        std::copy(frame.begin(), frame.end(), buf);
+        return {periph::LoRaStatusCode::Ok, frame.size(), signal};
+    }
+
+    std::vector<std::uint8_t> default_frame_payload() {
+        return {default_frame.begin(), default_frame.end()};
+    }
+}
+
 periph::LoRaStatusCode periph::SX1262Module::init() {
     _initialized = true;
+    _default_frame_emitted = false;
+    _pending_frames.clear();
     return periph::LoRaStatusCode::Ok;
 }
 
@@ -19,7 +47,7 @@ periph::LoRaTransmitResult periph::SX1262Module::transmit(const uint8_t *buf, si
     if (buf == nullptr && len > 0)
         return {periph::LoRaStatusCode::InvalidArgument, 0};
 
-    // TODO: Wire actual SX1262 TX implementation.
+    _pending_frames.emplace_back(buf, buf + len);
     return {periph::LoRaStatusCode::Ok, len};
 }
 
@@ -28,9 +56,16 @@ periph::LoRaReceiveResult periph::SX1262Module::receive(uint8_t *buf, size_t max
     if (!_initialized)
         return {periph::LoRaStatusCode::NotInitialized, 0, {}};
 
-    if (buf == nullptr && max_len > 0)
-        return {periph::LoRaStatusCode::InvalidArgument, 0, {}};
+    if (!_pending_frames.empty()) {
+        const std::vector<std::uint8_t> frame = _pending_frames.front();
+        _pending_frames.pop_front();
+        return copy_frame(buf, max_len, frame, default_signal);
+    }
 
-    // TODO: Wire actual SX1262 RX implementation.
-    return {periph::LoRaStatusCode::Timeout, 0, {}};
+    if (_default_frame_emitted)
+        return {periph::LoRaStatusCode::Timeout, 0, {}};
+
+    _default_frame_emitted = true;
+    const std::vector<std::uint8_t> frame = default_frame_payload();
+    return copy_frame(buf, max_len, frame, default_signal);
 }

--- a/LoRa/src/periph/sx1262_module.cc
+++ b/LoRa/src/periph/sx1262_module.cc
@@ -1,6 +1,6 @@
 /**
  * @file sx1262_module.cc
- * @brief Virtual SX1262 LoRa backend implementation
+ * @brief Virtual SX1262 LoRa module implementation
  * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
  * @note Origin: Long Beach Rocketry
  */

--- a/LoRa/src/periph/sx1262_module.cc
+++ b/LoRa/src/periph/sx1262_module.cc
@@ -7,15 +7,23 @@
 
 #include "periph/sx1262_module.h"
 
-bool periph::SX1262Module::init() {
-    return true;
+periph::LoRaStatusCode periph::SX1262Module::init() {
+    return periph::LoRaStatusCode::Ok;
 }
 
-void periph::SX1262Module::transmit(uint8_t * /*buf*/, size_t /*len*/) {
+periph::LoRaTransmitResult periph::SX1262Module::transmit(const uint8_t *buf, size_t len) {
+    if (buf == nullptr && len > 0)
+        return {periph::LoRaStatusCode::InvalidArgument, 0};
+
     // TODO: Wire actual SX1262 TX implementation.
+    return {periph::LoRaStatusCode::Ok, len};
 }
 
-int periph::SX1262Module::receive(uint8_t * /*buf*/) {
+periph::LoRaReceiveResult periph::SX1262Module::receive(uint8_t *buf, size_t max_len,
+                                                        uint32_t /*timeout_ms*/) {
+    if (buf == nullptr && max_len > 0)
+        return {periph::LoRaStatusCode::InvalidArgument, 0, {}};
+
     // TODO: Wire actual SX1262 RX implementation.
-    return 0;
+    return {periph::LoRaStatusCode::Timeout, 0, {}};
 }

--- a/LoRa/src/periph/sx127_module.cc
+++ b/LoRa/src/periph/sx127_module.cc
@@ -1,6 +1,6 @@
 /**
  * @file sx127_module.cc
- * @brief Virtual SX127 LoRa backend implementation
+ * @brief Virtual SX127 LoRa module implementation
  * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
  * @note Origin: Long Beach Rocketry
  */

--- a/LoRa/src/periph/sx127_module.cc
+++ b/LoRa/src/periph/sx127_module.cc
@@ -8,10 +8,14 @@
 #include "periph/sx127_module.h"
 
 periph::LoRaStatusCode periph::SX127Module::init() {
+    _initialized = true;
     return periph::LoRaStatusCode::Ok;
 }
 
 periph::LoRaTransmitResult periph::SX127Module::transmit(const uint8_t *buf, size_t len) {
+    if (!_initialized)
+        return {periph::LoRaStatusCode::NotInitialized, 0};
+
     if (buf == nullptr && len > 0)
         return {periph::LoRaStatusCode::InvalidArgument, 0};
 
@@ -21,6 +25,9 @@ periph::LoRaTransmitResult periph::SX127Module::transmit(const uint8_t *buf, siz
 
 periph::LoRaReceiveResult periph::SX127Module::receive(uint8_t *buf, size_t max_len,
                                                        uint32_t /*timeout_ms*/) {
+    if (!_initialized)
+        return {periph::LoRaStatusCode::NotInitialized, 0, {}};
+
     if (buf == nullptr && max_len > 0)
         return {periph::LoRaStatusCode::InvalidArgument, 0, {}};
 

--- a/LoRa/src/periph/sx127_module.cc
+++ b/LoRa/src/periph/sx127_module.cc
@@ -7,15 +7,23 @@
 
 #include "periph/sx127_module.h"
 
-bool periph::SX127Module::init() {
-    return true;
+periph::LoRaStatusCode periph::SX127Module::init() {
+    return periph::LoRaStatusCode::Ok;
 }
 
-void periph::SX127Module::transmit(uint8_t * /*buf*/, size_t /*len*/) {
+periph::LoRaTransmitResult periph::SX127Module::transmit(const uint8_t *buf, size_t len) {
+    if (buf == nullptr && len > 0)
+        return {periph::LoRaStatusCode::InvalidArgument, 0};
+
     // TODO: Wire actual SX127 TX implementation.
+    return {periph::LoRaStatusCode::Ok, len};
 }
 
-int periph::SX127Module::receive(uint8_t * /*buf*/) {
+periph::LoRaReceiveResult periph::SX127Module::receive(uint8_t *buf, size_t max_len,
+                                                       uint32_t /*timeout_ms*/) {
+    if (buf == nullptr && max_len > 0)
+        return {periph::LoRaStatusCode::InvalidArgument, 0, {}};
+
     // TODO: Wire actual SX127 RX implementation.
-    return 0;
+    return {periph::LoRaStatusCode::Timeout, 0, {}};
 }

--- a/LoRa/src/periph/sx127_module.cc
+++ b/LoRa/src/periph/sx127_module.cc
@@ -1,14 +1,42 @@
 /**
  * @file sx127_module.cc
- * @brief Skeleton SX127 LoRa backend implementation
+ * @brief Virtual SX127 LoRa backend implementation
  * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
  * @note Origin: Long Beach Rocketry
  */
 
 #include "periph/sx127_module.h"
 
+#include <array>
+#include <algorithm>
+
+namespace {
+    constexpr std::array<std::uint8_t, 6> default_frame{{2U, 0x10U, 0x00U, 0xF4U, 0x01U, 87U}};
+    const periph::LoRaSignalMetrics default_signal{true, -84, 7.5F};
+
+    periph::LoRaReceiveResult copy_frame(uint8_t *buf,
+                                         size_t max_len,
+                                         const std::vector<std::uint8_t> &frame,
+                                         const periph::LoRaSignalMetrics &signal) {
+        if (buf == nullptr && max_len > 0)
+            return {periph::LoRaStatusCode::InvalidArgument, 0, {}};
+
+        if (max_len < frame.size())
+            return {periph::LoRaStatusCode::InvalidArgument, 0, {}};
+
+        std::copy(frame.begin(), frame.end(), buf);
+        return {periph::LoRaStatusCode::Ok, frame.size(), signal};
+    }
+
+    std::vector<std::uint8_t> default_frame_payload() {
+        return {default_frame.begin(), default_frame.end()};
+    }
+}
+
 periph::LoRaStatusCode periph::SX127Module::init() {
     _initialized = true;
+    _default_frame_emitted = false;
+    _pending_frames.clear();
     return periph::LoRaStatusCode::Ok;
 }
 
@@ -19,7 +47,7 @@ periph::LoRaTransmitResult periph::SX127Module::transmit(const uint8_t *buf, siz
     if (buf == nullptr && len > 0)
         return {periph::LoRaStatusCode::InvalidArgument, 0};
 
-    // TODO: Wire actual SX127 TX implementation.
+    _pending_frames.emplace_back(buf, buf + len);
     return {periph::LoRaStatusCode::Ok, len};
 }
 
@@ -28,9 +56,16 @@ periph::LoRaReceiveResult periph::SX127Module::receive(uint8_t *buf, size_t max_
     if (!_initialized)
         return {periph::LoRaStatusCode::NotInitialized, 0, {}};
 
-    if (buf == nullptr && max_len > 0)
-        return {periph::LoRaStatusCode::InvalidArgument, 0, {}};
+    if (!_pending_frames.empty()) {
+        const std::vector<std::uint8_t> frame = _pending_frames.front();
+        _pending_frames.pop_front();
+        return copy_frame(buf, max_len, frame, default_signal);
+    }
 
-    // TODO: Wire actual SX127 RX implementation.
-    return {periph::LoRaStatusCode::Timeout, 0, {}};
+    if (_default_frame_emitted)
+        return {periph::LoRaStatusCode::Timeout, 0, {}};
+
+    _default_frame_emitted = true;
+    const std::vector<std::uint8_t> frame = default_frame_payload();
+    return copy_frame(buf, max_len, frame, default_signal);
 }

--- a/LoRa/src/sdr_pipeline.cc
+++ b/LoRa/src/sdr_pipeline.cc
@@ -7,25 +7,54 @@
 
 #include "sdr_pipeline.h"
 
+#include "telemetry/interpreter.h"
+
 #include <array>
 #include <iostream>
 #include <stdexcept>
 
-SDRPipeline::SDRPipeline(const cli::RuntimeSettings &settings, periph::ILoRaModule *lora_module)
+namespace {
+    const char *status_to_string(periph::LoRaStatusCode status) {
+        switch (status) {
+            case periph::LoRaStatusCode::Ok:
+                return "ok";
+            case periph::LoRaStatusCode::Timeout:
+                return "timeout";
+            case periph::LoRaStatusCode::InvalidArgument:
+                return "invalid_argument";
+            case periph::LoRaStatusCode::NotInitialized:
+                return "not_initialized";
+            case periph::LoRaStatusCode::IoError:
+                return "io_error";
+            case periph::LoRaStatusCode::Unsupported:
+                return "unsupported";
+            case periph::LoRaStatusCode::UnknownError:
+                return "unknown_error";
+        }
+
+        return "unknown_error";
+    }
+}
+
+SDRPipeline::SDRPipeline(const cli::RuntimeSettings &settings, periph::ILoRaModule &lora_module)
     : _settings(settings), _lora_module(lora_module) {}
 
 void SDRPipeline::run() {
-    if (_lora_module == nullptr)
-        throw std::invalid_argument("LoRa module pointer must not be null.");
-
-    if (!_lora_module->init())
-        throw std::runtime_error("Failed to initialize LoRa module.");
+    const periph::LoRaStatusCode init_status = _lora_module.init();
+    if (init_status != periph::LoRaStatusCode::Ok)
+        throw std::runtime_error(std::string("Failed to initialize LoRa module: ") +
+                                 status_to_string(init_status));
 
     if (!_settings.pipeline.verbose)
         return;
 
     std::array<uint8_t, 256> telemetry_buffer {};
-    const int received_len = _lora_module->receive(telemetry_buffer.data());
+    const periph::LoRaReceiveResult receive_result =
+        _lora_module.receive(telemetry_buffer.data(), telemetry_buffer.size(), 50);
+    if (receive_result.status != periph::LoRaStatusCode::Ok &&
+        receive_result.status != periph::LoRaStatusCode::Timeout)
+        throw std::runtime_error(std::string("Failed to receive telemetry: ") +
+                                 status_to_string(receive_result.status));
 
     std::cout << "Starting SDR pipeline\n"
               << "  device: " << _settings.sdr.device << '\n'
@@ -34,5 +63,16 @@ void SDRPipeline::run() {
               << "  gain_db: " << _settings.sdr.gain_db << '\n'
               << "  output_path: " << _settings.pipeline.output_path << '\n'
               << "  lora_module: " << _settings.lora.module << '\n'
-              << "  telemetry_bytes_received: " << received_len << '\n';
+              << "  telemetry_status: " << status_to_string(receive_result.status) << '\n'
+              << "  telemetry_bytes_received: " << receive_result.bytes_received << '\n';
+
+    if (!_settings.pipeline.interpret_telemetry)
+        return;
+
+    const telemetry::DecodedTelemetry decoded =
+        telemetry::Interpreter::decode(telemetry_buffer.data(), receive_result.bytes_received);
+    if (decoded.decoded)
+        std::cout << "  telemetry_decode: " << decoded.summary << '\n';
+    else
+        std::cout << "  telemetry_decode: unavailable (" << decoded.summary << ")\n";
 }

--- a/LoRa/src/sdr_pipeline.cc
+++ b/LoRa/src/sdr_pipeline.cc
@@ -10,6 +10,8 @@
 #include "telemetry/interpreter.h"
 
 #include <array>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <stdexcept>
 
@@ -33,6 +35,26 @@ namespace {
         }
 
         return "unknown_error";
+    }
+
+    void persist_payload(const std::string &output_path,
+                         const std::uint8_t *payload,
+                         std::size_t payload_len) {
+        if (payload_len == 0)
+            return;
+
+        std::filesystem::path path(output_path);
+        const std::filesystem::path parent = path.parent_path();
+        if (!parent.empty())
+            std::filesystem::create_directories(parent);
+
+        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        if (!out)
+            throw std::runtime_error("Failed to open telemetry output file: " + output_path);
+
+        out.write(reinterpret_cast<const char *>(payload), static_cast<std::streamsize>(payload_len));
+        if (!out)
+            throw std::runtime_error("Failed to write telemetry output file: " + output_path);
     }
 }
 
@@ -65,6 +87,10 @@ void SDRPipeline::run() {
               << "  lora_module: " << _settings.lora.module << '\n'
               << "  telemetry_status: " << status_to_string(receive_result.status) << '\n'
               << "  telemetry_bytes_received: " << receive_result.bytes_received << '\n';
+
+    persist_payload(_settings.pipeline.output_path,
+                    telemetry_buffer.data(),
+                    receive_result.bytes_received);
 
     if (!_settings.pipeline.interpret_telemetry)
         return;

--- a/LoRa/src/telemetry/interpreter.cc
+++ b/LoRa/src/telemetry/interpreter.cc
@@ -1,0 +1,37 @@
+/**
+ * @file interpreter.cc
+ * @brief Lightweight telemetry payload interpreter
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#include "telemetry/interpreter.h"
+
+#include <sstream>
+
+telemetry::DecodedTelemetry telemetry::Interpreter::decode(const uint8_t *payload,
+                                                          size_t payload_len) {
+    if (payload == nullptr)
+        return {false, "missing payload buffer"};
+ 
+    // Minimal frame contract used for now:
+    // [0]=mode, [1..2]=altitude_m (LE), [3..4]=velocity_cms (LE), [5]=battery_percent
+    if (payload_len < 6)
+        return {false, "payload too short for telemetry_v1"};
+
+    const uint8_t mode = payload[0];
+    const uint16_t altitude_m =
+        static_cast<uint16_t>(payload[1]) | (static_cast<uint16_t>(payload[2]) << 8);
+    const uint16_t velocity_cms =
+        static_cast<uint16_t>(payload[3]) | (static_cast<uint16_t>(payload[4]) << 8);
+    const uint8_t battery_percent = payload[5];
+
+    std::ostringstream summary;
+    summary << "telemetry_v1"
+            << " mode=" << static_cast<int>(mode)
+            << " altitude_m=" << altitude_m
+            << " velocity_cms=" << velocity_cms
+            << " battery_percent=" << static_cast<int>(battery_percent);
+
+    return {true, summary.str()};
+}

--- a/LoRa/tests/config_tests.cc
+++ b/LoRa/tests/config_tests.cc
@@ -64,7 +64,7 @@ TEST(ConfigTests, All) {
             "  gain_db: 12\n"
             "lora:\n"
             "  module: \"sx127\"\n"
-            "  backend: \"virtual\"\n"
+            "  mode: \"virtual\"\n"
             "pipeline:\n"
             "  verbose: false\n"
             "  interpret_telemetry: false\n"
@@ -79,24 +79,24 @@ TEST(ConfigTests, All) {
         EXPECT_EQ(config.settings().sdr.center_freq_hz, 915000000);
         EXPECT_EQ(config.settings().sdr.gain_db, 12);
         EXPECT_EQ(config.settings().lora.module, std::string("sx127"));
-        EXPECT_EQ(config.settings().lora.backend, std::string("virtual"));
+        EXPECT_EQ(config.settings().lora.mode, std::string("virtual"));
         EXPECT_EQ(config.settings().pipeline.output_path, std::string("telemetry.bin"));
         EXPECT_FALSE(config.settings().pipeline.verbose);
         EXPECT_FALSE(config.settings().pipeline.interpret_telemetry);
     }
 
     {
-        tests::ArgvBuilder builder({"app.exe", "--lora-backend", "virtual"});
+        tests::ArgvBuilder builder({"app.exe", "--lora-mode", "virtual"});
         cli::Config config;
         EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::Ok);
-        EXPECT_EQ(config.settings().lora.backend, std::string("virtual"));
+        EXPECT_EQ(config.settings().lora.mode, std::string("virtual"));
     }
 
     {
-        tests::ArgvBuilder builder({"app.exe", "--lora-backend", "hardware"});
+        tests::ArgvBuilder builder({"app.exe", "--lora-mode", "hardware"});
         cli::Config config;
         EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::Ok);
-        EXPECT_EQ(config.settings().lora.backend, std::string("hardware"));
+        EXPECT_EQ(config.settings().lora.mode, std::string("hardware"));
     }
 
     {
@@ -113,7 +113,7 @@ TEST(ConfigTests, All) {
     }
 
     {
-        tests::ArgvBuilder builder({"app.exe", "--lora-backend", "bad"});
+        tests::ArgvBuilder builder({"app.exe", "--lora-mode", "bad"});
         cli::Config config;
         EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::ExitFailure);
     }
@@ -227,7 +227,7 @@ TEST(ConfigTests, All) {
     }
 
     {
-        tests::ScopedTempFile file("lora:\n  backend: [virtual]\n");
+        tests::ScopedTempFile file("lora:\n  mode: [virtual]\n");
         tests::ArgvBuilder builder({"app.exe", "-c", file.path().string()});
         cli::Config config;
         EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::ExitFailure);
@@ -262,7 +262,7 @@ TEST(ConfigTests, All) {
     }
 
     {
-        tests::ScopedTempFile file("lora:\n  backend: \"invalid\"\n");
+        tests::ScopedTempFile file("lora:\n  mode: \"invalid\"\n");
         tests::ArgvBuilder builder({"app.exe", "-c", file.path().string()});
         cli::Config config;
         EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::ExitFailure);

--- a/LoRa/tests/config_tests.cc
+++ b/LoRa/tests/config_tests.cc
@@ -64,6 +64,7 @@ TEST(ConfigTests, All) {
             "  gain_db: 12\n"
             "lora:\n"
             "  module: \"sx127\"\n"
+            "  backend: \"virtual\"\n"
             "pipeline:\n"
             "  verbose: false\n"
             "  interpret_telemetry: false\n"
@@ -78,9 +79,24 @@ TEST(ConfigTests, All) {
         EXPECT_EQ(config.settings().sdr.center_freq_hz, 915000000);
         EXPECT_EQ(config.settings().sdr.gain_db, 12);
         EXPECT_EQ(config.settings().lora.module, std::string("sx127"));
+        EXPECT_EQ(config.settings().lora.backend, std::string("virtual"));
         EXPECT_EQ(config.settings().pipeline.output_path, std::string("telemetry.bin"));
         EXPECT_FALSE(config.settings().pipeline.verbose);
         EXPECT_FALSE(config.settings().pipeline.interpret_telemetry);
+    }
+
+    {
+        tests::ArgvBuilder builder({"app.exe", "--lora-backend", "virtual"});
+        cli::Config config;
+        EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::Ok);
+        EXPECT_EQ(config.settings().lora.backend, std::string("virtual"));
+    }
+
+    {
+        tests::ArgvBuilder builder({"app.exe", "--lora-backend", "hardware"});
+        cli::Config config;
+        EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::Ok);
+        EXPECT_EQ(config.settings().lora.backend, std::string("hardware"));
     }
 
     {
@@ -92,6 +108,12 @@ TEST(ConfigTests, All) {
 
     {
         tests::ArgvBuilder builder({"app.exe", "--lora-module", "bad"});
+        cli::Config config;
+        EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::ExitFailure);
+    }
+
+    {
+        tests::ArgvBuilder builder({"app.exe", "--lora-backend", "bad"});
         cli::Config config;
         EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::ExitFailure);
     }
@@ -205,6 +227,13 @@ TEST(ConfigTests, All) {
     }
 
     {
+        tests::ScopedTempFile file("lora:\n  backend: [virtual]\n");
+        tests::ArgvBuilder builder({"app.exe", "-c", file.path().string()});
+        cli::Config config;
+        EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::ExitFailure);
+    }
+
+    {
         tests::ScopedTempFile file("sdr:\n  center_freq_hz: 0\n");
         tests::ArgvBuilder builder({"app.exe", "-c", file.path().string()});
         cli::Config config;
@@ -227,6 +256,13 @@ TEST(ConfigTests, All) {
 
     {
         tests::ScopedTempFile file("lora:\n  module: \"invalid\"\n");
+        tests::ArgvBuilder builder({"app.exe", "-c", file.path().string()});
+        cli::Config config;
+        EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::ExitFailure);
+    }
+
+    {
+        tests::ScopedTempFile file("lora:\n  backend: \"invalid\"\n");
         tests::ArgvBuilder builder({"app.exe", "-c", file.path().string()});
         cli::Config config;
         EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::ExitFailure);

--- a/LoRa/tests/config_tests.cc
+++ b/LoRa/tests/config_tests.cc
@@ -66,6 +66,7 @@ TEST(ConfigTests, All) {
             "  module: \"sx127\"\n"
             "pipeline:\n"
             "  verbose: false\n"
+            "  interpret_telemetry: false\n"
             "  output_path: \"telemetry.bin\"\n");
 
         tests::ArgvBuilder builder({"app.exe", "-c", file.path().string()});
@@ -79,6 +80,7 @@ TEST(ConfigTests, All) {
         EXPECT_EQ(config.settings().lora.module, std::string("sx127"));
         EXPECT_EQ(config.settings().pipeline.output_path, std::string("telemetry.bin"));
         EXPECT_FALSE(config.settings().pipeline.verbose);
+        EXPECT_FALSE(config.settings().pipeline.interpret_telemetry);
     }
 
     {
@@ -176,6 +178,13 @@ TEST(ConfigTests, All) {
 
     {
         tests::ScopedTempFile file("pipeline:\n  verbose: [true]\n");
+        tests::ArgvBuilder builder({"app.exe", "-c", file.path().string()});
+        cli::Config config;
+        EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::ExitFailure);
+    }
+
+    {
+        tests::ScopedTempFile file("pipeline:\n  interpret_telemetry: [true]\n");
         tests::ArgvBuilder builder({"app.exe", "-c", file.path().string()});
         cli::Config config;
         EXPECT_EQ(parse_silent(config, builder.build()), cli::ParseStatus::ExitFailure);

--- a/LoRa/tests/connector_tests.cc
+++ b/LoRa/tests/connector_tests.cc
@@ -8,6 +8,8 @@
 #include <gtest/gtest.h>
 
 #include "connector/local_tcp_transport.h"
+#include "connector/local_udp_transport.h"
+#include "connector/local_zmq_transport.h"
 #include "connector/message.h"
 #include "connector/ndjson_file.h"
 
@@ -30,7 +32,7 @@ TEST(ConnectorTests, MessageRoundTripJson) {
     message.message_type = "telemetry_frame";
     message.sequence = 7;
     message.timestamp_ms = 1234567890;
-    message.source = connector::Source::Sx1262;
+    message.source = "sx1262";
     message.payload = {0x01, 0x02, 0x03, 0x04};
     message.checksum_hex = "AB12";
     message.metadata["frame_type"] = "telemetry";
@@ -42,7 +44,7 @@ TEST(ConnectorTests, MessageRoundTripJson) {
     EXPECT_EQ(parsed.message_type, "telemetry_frame");
     EXPECT_EQ(parsed.sequence, 7u);
     EXPECT_EQ(parsed.timestamp_ms, 1234567890);
-    EXPECT_EQ(parsed.source, connector::Source::Sx1262);
+    EXPECT_EQ(parsed.source, std::string("sx1262"));
     EXPECT_EQ(parsed.payload, message.payload);
     EXPECT_TRUE(parsed.checksum_hex.has_value());
     EXPECT_EQ(*parsed.checksum_hex, "AB12");
@@ -67,20 +69,20 @@ TEST(ConnectorTests, MessageRoundTripWithoutOptionalFields) {
     connector::ConnectorMessage message;
     message.sequence = 12;
     message.timestamp_ms = 333;
-    message.source = connector::Source::Sx127;
+    message.source = "sx127";
     message.payload = {0x10};
 
     const connector::ConnectorMessage parsed = connector::ConnectorMessage::from_json(message.to_json());
     EXPECT_EQ(parsed.sequence, 12u);
     EXPECT_EQ(parsed.timestamp_ms, 333);
-    EXPECT_EQ(parsed.source, connector::Source::Sx127);
+    EXPECT_EQ(parsed.source, std::string("sx127"));
     EXPECT_FALSE(parsed.checksum_hex.has_value());
     EXPECT_TRUE(parsed.metadata.empty());
 }
 
 TEST(ConnectorTests, MessageToJsonRejectsUnsupportedSchemaVersion) {
     connector::ConnectorMessage message;
-    message.schema_version = 2;
+    message.schema_version = 0;
     message.payload = {0x01};
 
     EXPECT_THROW(static_cast<void>(message.to_json()), std::runtime_error);
@@ -88,7 +90,7 @@ TEST(ConnectorTests, MessageToJsonRejectsUnsupportedSchemaVersion) {
 
 TEST(ConnectorTests, MessageToJsonRejectsUnsupportedMessageType) {
     connector::ConnectorMessage message;
-    message.message_type = "status";
+    message.message_type.clear();
     message.payload = {0x01};
 
     EXPECT_THROW(static_cast<void>(message.to_json()), std::runtime_error);
@@ -108,9 +110,30 @@ TEST(ConnectorTests, MessageFromJsonRejectsInvalidBase64) {
                  std::runtime_error);
 }
 
-TEST(ConnectorTests, MessageFromJsonRejectsUnknownSource) {
+TEST(ConnectorTests, MessageFromJsonAllowsCustomSource) {
+    const std::string custom_source =
+        R"({"schema_version":1,"message_type":"telemetry_frame","sequence":1,"timestamp_ms":1,"source":"vehicle.alpha","payload_b64":"AQ=="})";
+    const connector::ConnectorMessage parsed = connector::ConnectorMessage::from_json(custom_source);
+    EXPECT_EQ(parsed.source, std::string("vehicle.alpha"));
+}
+
+TEST(ConnectorTests, MessageFromJsonRejectsSchemaVersionZero) {
+    const std::string invalid_schema =
+        R"({"schema_version":0,"message_type":"telemetry_frame","sequence":1,"timestamp_ms":1,"source":"simulated","payload_b64":"AQ=="})";
+    EXPECT_THROW(static_cast<void>(connector::ConnectorMessage::from_json(invalid_schema)),
+                 std::runtime_error);
+}
+
+TEST(ConnectorTests, MessageFromJsonRejectsEmptyMessageType) {
+    const std::string invalid_type =
+        R"({"schema_version":1,"message_type":"","sequence":1,"timestamp_ms":1,"source":"simulated","payload_b64":"AQ=="})";
+    EXPECT_THROW(static_cast<void>(connector::ConnectorMessage::from_json(invalid_type)),
+                 std::runtime_error);
+}
+
+TEST(ConnectorTests, MessageFromJsonRejectsEmptySource) {
     const std::string invalid_source =
-        R"({"schema_version":1,"message_type":"telemetry_frame","sequence":1,"timestamp_ms":1,"source":"x","payload_b64":"AQ=="})";
+        R"({"schema_version":1,"message_type":"telemetry_frame","sequence":1,"timestamp_ms":1,"source":"","payload_b64":"AQ=="})";
     EXPECT_THROW(static_cast<void>(connector::ConnectorMessage::from_json(invalid_source)),
                  std::runtime_error);
 }
@@ -168,7 +191,7 @@ TEST(ConnectorTests, MessageRoundTripWithEscapedPayloadMetadataStrings) {
     connector::ConnectorMessage message;
     message.sequence = 88;
     message.timestamp_ms = 777;
-    message.source = connector::Source::Simulated;
+    message.source = "simulated";
     message.payload = {0x00, 0x0A, 0x1F};
     message.metadata["path"] = "C:\\tmp\\file";
     message.metadata["quote"] = "\"quoted\"";
@@ -185,7 +208,7 @@ TEST(ConnectorTests, MessageToJsonEscapesControlCharacters) {
     connector::ConnectorMessage message;
     message.sequence = 1;
     message.timestamp_ms = 2;
-    message.source = connector::Source::Simulated;
+    message.source = "simulated";
     message.payload = {0x01};
     message.metadata["ctrl"] = std::string("a") + '\b' + '\f' + '\n' + '\r' + '\t' + '"' + '\\' + static_cast<char>(0x01);
 
@@ -208,6 +231,23 @@ TEST(ConnectorTests, MessageFromJsonAcceptsWhitespaceInBase64Payload) {
     EXPECT_EQ(parsed.payload[0], 0x01);
 }
 
+TEST(ConnectorTests, MessageRoundTripCustomProtocolEnvelope) {
+    connector::ConnectorMessage message;
+    message.schema_version = 3;
+    message.message_type = "telemetry_decoded";
+    message.sequence = 999;
+    message.timestamp_ms = 123;
+    message.source = "decoder.flight-v2";
+    message.payload = {0x41, 0x42};
+    message.metadata["protocol"] = "lbr.flight.v2";
+
+    const connector::ConnectorMessage parsed = connector::ConnectorMessage::from_json(message.to_json());
+    EXPECT_EQ(parsed.schema_version, 3);
+    EXPECT_EQ(parsed.message_type, std::string("telemetry_decoded"));
+    EXPECT_EQ(parsed.source, std::string("decoder.flight-v2"));
+    EXPECT_EQ(parsed.metadata.at("protocol"), std::string("lbr.flight.v2"));
+}
+
 TEST(ConnectorTests, NdjsonFileRoundTrip) {
     const std::filesystem::path file_path = temp_file_path("lbr_connector_roundtrip.ndjson");
     std::filesystem::remove(file_path);
@@ -215,7 +255,7 @@ TEST(ConnectorTests, NdjsonFileRoundTrip) {
     connector::ConnectorMessage message;
     message.sequence = 99;
     message.timestamp_ms = 1111;
-    message.source = connector::Source::Simulated;
+    message.source = "simulated";
     message.payload = {0xAA, 0xBB, 0xCC};
 
     {
@@ -229,7 +269,7 @@ TEST(ConnectorTests, NdjsonFileRoundTrip) {
         EXPECT_TRUE(reader.read_next(parsed));
         EXPECT_EQ(parsed.sequence, 99u);
         EXPECT_EQ(parsed.timestamp_ms, 1111);
-        EXPECT_EQ(parsed.source, connector::Source::Simulated);
+        EXPECT_EQ(parsed.source, std::string("simulated"));
         EXPECT_EQ(parsed.payload, message.payload);
     }
 
@@ -309,7 +349,7 @@ TEST(ConnectorTests, LocalTcpTransportExchange) {
                                      "telemetry_frame",
                                      1,
                                      42,
-                                     connector::Source::Simulated,
+                                     "simulated",
                                      {0x11, 0x22},
                                      std::nullopt,
                                      {}}.to_json();
@@ -433,4 +473,113 @@ TEST(ConnectorTests, LocalTcpTransportSupportsEmptyHostAlias) {
 
     server_thread.join();
     EXPECT_EQ(received, "");
+}
+
+TEST(ConnectorTests, LocalUdpTransportExchange) {
+    constexpr std::uint16_t port = 45690;
+    const std::string payload =
+        connector::ConnectorMessage{1,
+                                    "telemetry_frame",
+                                    22,
+                                    123,
+                                    "simulated",
+                                    {0xDE, 0xAD, 0xBE, 0xEF},
+                                    std::nullopt,
+                                    {}}.to_json();
+
+    std::string received;
+
+    std::thread server_thread([&received, port]() {
+        connector::LocalUdpTransport server(connector::LocalUdpMode::Server, "127.0.0.1", port);
+        server.open();
+        ASSERT_TRUE(server.read_datagram(received, 2000));
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    connector::LocalUdpTransport client(connector::LocalUdpMode::Client, "127.0.0.1", port);
+    client.open();
+    client.write_datagram(payload);
+
+    server_thread.join();
+
+    ASSERT_FALSE(received.empty());
+    EXPECT_EQ(connector::ConnectorMessage::from_json(received).sequence, 22u);
+}
+
+TEST(ConnectorTests, LocalUdpTransportReadTimesOutWithoutBlocking) {
+    constexpr std::uint16_t port = 45691;
+
+    connector::LocalUdpTransport server(connector::LocalUdpMode::Server, "127.0.0.1", port);
+    server.open();
+
+    std::string payload;
+    const auto start = std::chrono::steady_clock::now();
+    const bool has_data = server.read_datagram(payload, 100);
+    const auto elapsed_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
+                                                               start)
+            .count();
+
+    EXPECT_FALSE(has_data);
+    EXPECT_TRUE(payload.empty());
+    EXPECT_GE(elapsed_ms, 50);
+    EXPECT_LT(elapsed_ms, 1000);
+}
+
+TEST(ConnectorTests, LocalUdpTransportWriteBeforeOpenThrows) {
+    connector::LocalUdpTransport transport(connector::LocalUdpMode::Client, "127.0.0.1", 45692);
+    EXPECT_THROW(transport.write_datagram("hello"), std::runtime_error);
+}
+
+TEST(ConnectorTests, LocalUdpTransportReadBeforeOpenThrows) {
+    connector::LocalUdpTransport transport(connector::LocalUdpMode::Client, "127.0.0.1", 45693);
+    std::string payload;
+    EXPECT_THROW(static_cast<void>(transport.read_datagram(payload, 5)), std::runtime_error);
+}
+
+TEST(ConnectorTests, LocalUdpTransportServerCannotSendBeforeLearningPeer) {
+    connector::LocalUdpTransport server(connector::LocalUdpMode::Server, "127.0.0.1", 45694);
+    server.open();
+    EXPECT_THROW(server.write_datagram("payload"), std::runtime_error);
+}
+
+TEST(ConnectorTests, LocalZmqTransportThrowsWhenNotBuiltWithZmq) {
+#if defined(LBR_HAS_ZEROMQ) && LBR_HAS_ZEROMQ
+    SUCCEED();
+#else
+    connector::LocalZmqTransport publisher(connector::LocalZmqMode::Publisher,
+                                           "tcp://127.0.0.1:5560",
+                                           "telemetry");
+    EXPECT_THROW(static_cast<void>(publisher.open()), std::runtime_error);
+#endif
+}
+
+TEST(ConnectorTests, LocalZmqTransportPubSubExchange) {
+#if defined(LBR_HAS_ZEROMQ) && LBR_HAS_ZEROMQ
+    constexpr const char *endpoint = "tcp://127.0.0.1:5561";
+    constexpr const char *topic = "telemetry";
+    std::string received;
+
+    std::thread subscriber_thread([&received]() {
+        connector::LocalZmqTransport subscriber(connector::LocalZmqMode::Subscriber,
+                                                endpoint,
+                                                topic);
+        subscriber.open();
+        ASSERT_TRUE(subscriber.receive_message(received, 3000));
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    connector::LocalZmqTransport publisher(connector::LocalZmqMode::Publisher,
+                                           endpoint,
+                                           topic);
+    publisher.open();
+    publisher.send_message("payload-via-zmq");
+
+    subscriber_thread.join();
+    EXPECT_EQ(received, "payload-via-zmq");
+#else
+    GTEST_SKIP() << "ZeroMQ not enabled in this build.";
+#endif
 }

--- a/LoRa/tests/connector_tests.cc
+++ b/LoRa/tests/connector_tests.cc
@@ -159,11 +159,11 @@ TEST(ConnectorTests, MessageFromJsonRejectsInvalidEscapes) {
                  std::runtime_error);
 }
 
-TEST(ConnectorTests, MessageFromJsonRejectsUnsupportedUnicodeEscape) {
+TEST(ConnectorTests, MessageFromJsonAcceptsUnicodeEscape) {
     const std::string unicode_escape =
         R"({"schema_version":1,"message_type":"telemetry_frame","sequence":1,"timestamp_ms":1,"source":"simulated","payload_b64":"AQ==","metadata":{"bad":"\u0041"}})";
-    EXPECT_THROW(static_cast<void>(connector::ConnectorMessage::from_json(unicode_escape)),
-                 std::runtime_error);
+    const connector::ConnectorMessage parsed = connector::ConnectorMessage::from_json(unicode_escape);
+    EXPECT_EQ(parsed.metadata.at("bad"), std::string("A"));
 }
 
 TEST(ConnectorTests, MessageFromJsonRejectsMalformedMetadataObject) {

--- a/LoRa/tests/pipeline_tests.cc
+++ b/LoRa/tests/pipeline_tests.cc
@@ -12,6 +12,8 @@
 #include "sdr_pipeline.h"
 #include "test_common.h"
 
+#include <filesystem>
+#include <fstream>
 #include <string>
 
 namespace {
@@ -129,4 +131,44 @@ TEST(PipelineTests, Sx127SkeletonMethodsAreCallable) {
     const periph::LoRaReceiveResult receive_result = module.receive(buffer, sizeof(buffer), 50);
     EXPECT_EQ(receive_result.status, periph::LoRaStatusCode::Timeout);
     EXPECT_EQ(receive_result.bytes_received, 0U);
+}
+
+TEST(PipelineTests, WritesReceivedPayloadToOutputFile) {
+    const std::filesystem::path output_path =
+        std::filesystem::temp_directory_path() / "lbr_pipeline_output_test.bin";
+    std::error_code ec;
+    std::filesystem::remove(output_path, ec);
+
+    cli::RuntimeSettings settings;
+    settings.pipeline.verbose = true;
+    settings.pipeline.output_path = output_path.string();
+    settings.pipeline.interpret_telemetry = false;
+    FakeLoRaModule module;
+
+    SDRPipeline pipeline(settings, module);
+    pipeline.run();
+
+    std::ifstream in(output_path, std::ios::binary);
+    ASSERT_TRUE(in.good());
+    std::string bytes((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    ASSERT_EQ(bytes.size(), static_cast<std::size_t>(6));
+    EXPECT_EQ(static_cast<unsigned char>(bytes[0]), 2U);
+    EXPECT_EQ(static_cast<unsigned char>(bytes[1]), 0x10U);
+    EXPECT_EQ(static_cast<unsigned char>(bytes[2]), 0x00U);
+    EXPECT_EQ(static_cast<unsigned char>(bytes[3]), 0xF4U);
+    EXPECT_EQ(static_cast<unsigned char>(bytes[4]), 0x01U);
+    EXPECT_EQ(static_cast<unsigned char>(bytes[5]), 87U);
+
+    std::filesystem::remove(output_path, ec);
+}
+
+TEST(PipelineTests, InvalidOutputPathThrowsWhenPayloadMustBePersisted) {
+    cli::RuntimeSettings settings;
+    settings.pipeline.verbose = true;
+    settings.pipeline.output_path = "";
+    settings.pipeline.interpret_telemetry = false;
+    FakeLoRaModule module;
+
+    SDRPipeline pipeline(settings, module);
+    EXPECT_THROW(static_cast<void>(pipeline.run()), std::runtime_error);
 }

--- a/LoRa/tests/pipeline_tests.cc
+++ b/LoRa/tests/pipeline_tests.cc
@@ -17,20 +17,33 @@
 namespace {
     class FakeLoRaModule final : public periph::ILoRaModule {
         public:
-            bool init() override {
+            periph::LoRaStatusCode init() override {
                 initialized = true;
-                return true;
+                return periph::LoRaStatusCode::Ok;
             }
 
-            void transmit(uint8_t * /*buf*/, size_t /*len*/) override {}
+            periph::LoRaTransmitResult transmit(const uint8_t *buf, size_t len) override {
+                if (buf == nullptr && len > 0)
+                    return {periph::LoRaStatusCode::InvalidArgument, 0};
 
-            int receive(uint8_t *buf) override {
+                return {periph::LoRaStatusCode::Ok, len};
+            }
+
+            periph::LoRaReceiveResult receive(uint8_t *buf, size_t max_len,
+                                              uint32_t /*timeout_ms*/) override {
                 if (buf == nullptr)
-                    return 0;
+                    return {periph::LoRaStatusCode::InvalidArgument, 0, {}};
 
-                buf[0] = 0xAA;
-                buf[1] = 0x55;
-                return 2;
+                if (max_len < 6)
+                    return {periph::LoRaStatusCode::InvalidArgument, 0, {}};
+
+                buf[0] = 2;
+                buf[1] = 0x10;
+                buf[2] = 0x00;
+                buf[3] = 0xF4;
+                buf[4] = 0x01;
+                buf[5] = 87;
+                return {periph::LoRaStatusCode::Ok, 6, {true, -84, 7.5F}};
             }
 
             bool initialized = false;
@@ -38,14 +51,17 @@ namespace {
 
     class FailingLoRaModule final : public periph::ILoRaModule {
         public:
-            bool init() override {
-                return false;
+            periph::LoRaStatusCode init() override {
+                return periph::LoRaStatusCode::IoError;
             }
 
-            void transmit(uint8_t * /*buf*/, size_t /*len*/) override {}
+            periph::LoRaTransmitResult transmit(const uint8_t * /*buf*/, size_t /*len*/) override {
+                return {periph::LoRaStatusCode::Unsupported, 0};
+            }
 
-            int receive(uint8_t * /*buf*/) override {
-                return 0;
+            periph::LoRaReceiveResult receive(uint8_t * /*buf*/, size_t /*max_len*/,
+                                              uint32_t /*timeout_ms*/) override {
+                return {periph::LoRaStatusCode::Unsupported, 0, {}};
             }
     };
 }
@@ -57,7 +73,7 @@ TEST(PipelineTests, All) {
         settings.pipeline.output_path = "silent.bin";
         FakeLoRaModule module;
 
-        SDRPipeline pipeline(settings, &module);
+        SDRPipeline pipeline(settings, module);
         const std::string output = tests::capture_stdout([&pipeline]() { pipeline.run(); });
         EXPECT_TRUE(output.empty());
         EXPECT_TRUE(module.initialized);
@@ -74,25 +90,21 @@ TEST(PipelineTests, All) {
         settings.lora.module = "sx1262";
         FakeLoRaModule module;
 
-        SDRPipeline pipeline(settings, &module);
+        SDRPipeline pipeline(settings, module);
         const std::string output = tests::capture_stdout([&pipeline]() { pipeline.run(); });
         EXPECT_NE(output.find("Starting SDR pipeline"), std::string::npos);
         EXPECT_NE(output.find("device: rtlsdr"), std::string::npos);
         EXPECT_NE(output.find("output_path: output/frame.bin"), std::string::npos);
         EXPECT_NE(output.find("lora_module: sx1262"), std::string::npos);
-        EXPECT_NE(output.find("telemetry_bytes_received: 2"), std::string::npos);
-    }
-
-    {
-        cli::RuntimeSettings settings;
-        SDRPipeline pipeline(settings, nullptr);
-        EXPECT_THROW(static_cast<void>(pipeline.run()), std::invalid_argument);
+        EXPECT_NE(output.find("telemetry_status: ok"), std::string::npos);
+        EXPECT_NE(output.find("telemetry_bytes_received: 6"), std::string::npos);
+        EXPECT_NE(output.find("telemetry_decode: telemetry_v1"), std::string::npos);
     }
 
     {
         cli::RuntimeSettings settings;
         FailingLoRaModule module;
-        SDRPipeline pipeline(settings, &module);
+        SDRPipeline pipeline(settings, module);
         EXPECT_THROW(static_cast<void>(pipeline.run()), std::runtime_error);
     }
 }
@@ -101,16 +113,20 @@ TEST(PipelineTests, Sx1262SkeletonMethodsAreCallable) {
     periph::SX1262Module module;
     uint8_t buffer[4] = {0, 0, 0, 0};
 
-    EXPECT_TRUE(module.init());
-    module.transmit(buffer, sizeof(buffer));
-    EXPECT_EQ(module.receive(buffer), 0);
+    EXPECT_EQ(module.init(), periph::LoRaStatusCode::Ok);
+    EXPECT_EQ(module.transmit(buffer, sizeof(buffer)).status, periph::LoRaStatusCode::Ok);
+    const periph::LoRaReceiveResult receive_result = module.receive(buffer, sizeof(buffer), 50);
+    EXPECT_EQ(receive_result.status, periph::LoRaStatusCode::Timeout);
+    EXPECT_EQ(receive_result.bytes_received, 0U);
 }
 
 TEST(PipelineTests, Sx127SkeletonMethodsAreCallable) {
     periph::SX127Module module;
     uint8_t buffer[4] = {0, 0, 0, 0};
 
-    EXPECT_TRUE(module.init());
-    module.transmit(buffer, sizeof(buffer));
-    EXPECT_EQ(module.receive(buffer), 0);
+    EXPECT_EQ(module.init(), periph::LoRaStatusCode::Ok);
+    EXPECT_EQ(module.transmit(buffer, sizeof(buffer)).status, periph::LoRaStatusCode::Ok);
+    const periph::LoRaReceiveResult receive_result = module.receive(buffer, sizeof(buffer), 50);
+    EXPECT_EQ(receive_result.status, periph::LoRaStatusCode::Timeout);
+    EXPECT_EQ(receive_result.bytes_received, 0U);
 }

--- a/LoRa/tests/pipeline_tests.cc
+++ b/LoRa/tests/pipeline_tests.cc
@@ -111,26 +111,61 @@ TEST(PipelineTests, All) {
     }
 }
 
-TEST(PipelineTests, Sx1262SkeletonMethodsAreCallable) {
+TEST(PipelineTests, Sx1262VirtualMethodsAreCallable) {
     periph::SX1262Module module;
-    uint8_t buffer[4] = {0, 0, 0, 0};
+    uint8_t buffer[6] = {0, 0, 0, 0, 0, 0};
 
     EXPECT_EQ(module.init(), periph::LoRaStatusCode::Ok);
-    EXPECT_EQ(module.transmit(buffer, sizeof(buffer)).status, periph::LoRaStatusCode::Ok);
     const periph::LoRaReceiveResult receive_result = module.receive(buffer, sizeof(buffer), 50);
-    EXPECT_EQ(receive_result.status, periph::LoRaStatusCode::Timeout);
-    EXPECT_EQ(receive_result.bytes_received, 0U);
+    EXPECT_EQ(receive_result.status, periph::LoRaStatusCode::Ok);
+    EXPECT_EQ(receive_result.bytes_received, 6U);
+    EXPECT_TRUE(receive_result.signal.has_signal_metrics);
+    EXPECT_EQ(static_cast<unsigned char>(buffer[0]), 2U);
+    EXPECT_EQ(static_cast<unsigned char>(buffer[1]), 0x10U);
+    EXPECT_EQ(static_cast<unsigned char>(buffer[2]), 0x00U);
+    EXPECT_EQ(static_cast<unsigned char>(buffer[3]), 0xF4U);
+    EXPECT_EQ(static_cast<unsigned char>(buffer[4]), 0x01U);
+    EXPECT_EQ(static_cast<unsigned char>(buffer[5]), 87U);
+
+    const uint8_t tx_payload[] = {0xAA, 0xBB, 0xCC};
+    EXPECT_EQ(module.transmit(tx_payload, sizeof(tx_payload)).status, periph::LoRaStatusCode::Ok);
+
+    uint8_t echoed[3] = {0, 0, 0};
+    const periph::LoRaReceiveResult echoed_result = module.receive(echoed, sizeof(echoed), 50);
+    EXPECT_EQ(echoed_result.status, periph::LoRaStatusCode::Ok);
+    EXPECT_EQ(echoed_result.bytes_received, 3U);
+    EXPECT_EQ(static_cast<unsigned char>(echoed[0]), 0xAAU);
+    EXPECT_EQ(static_cast<unsigned char>(echoed[1]), 0xBBU);
+    EXPECT_EQ(static_cast<unsigned char>(echoed[2]), 0xCCU);
 }
 
-TEST(PipelineTests, Sx127SkeletonMethodsAreCallable) {
+TEST(PipelineTests, Sx127VirtualMethodsAreCallable) {
     periph::SX127Module module;
-    uint8_t buffer[4] = {0, 0, 0, 0};
+    uint8_t buffer[6] = {0, 0, 0, 0, 0, 0};
 
     EXPECT_EQ(module.init(), periph::LoRaStatusCode::Ok);
-    EXPECT_EQ(module.transmit(buffer, sizeof(buffer)).status, periph::LoRaStatusCode::Ok);
     const periph::LoRaReceiveResult receive_result = module.receive(buffer, sizeof(buffer), 50);
-    EXPECT_EQ(receive_result.status, periph::LoRaStatusCode::Timeout);
-    EXPECT_EQ(receive_result.bytes_received, 0U);
+    EXPECT_EQ(receive_result.status, periph::LoRaStatusCode::Ok);
+    EXPECT_EQ(receive_result.bytes_received, 6U);
+    EXPECT_TRUE(receive_result.signal.has_signal_metrics);
+    EXPECT_EQ(static_cast<unsigned char>(buffer[0]), 2U);
+    EXPECT_EQ(static_cast<unsigned char>(buffer[1]), 0x10U);
+    EXPECT_EQ(static_cast<unsigned char>(buffer[2]), 0x00U);
+    EXPECT_EQ(static_cast<unsigned char>(buffer[3]), 0xF4U);
+    EXPECT_EQ(static_cast<unsigned char>(buffer[4]), 0x01U);
+    EXPECT_EQ(static_cast<unsigned char>(buffer[5]), 87U);
+
+    const uint8_t tx_payload[] = {0x11, 0x22, 0x33, 0x44};
+    EXPECT_EQ(module.transmit(tx_payload, sizeof(tx_payload)).status, periph::LoRaStatusCode::Ok);
+
+    uint8_t echoed[4] = {0, 0, 0, 0};
+    const periph::LoRaReceiveResult echoed_result = module.receive(echoed, sizeof(echoed), 50);
+    EXPECT_EQ(echoed_result.status, periph::LoRaStatusCode::Ok);
+    EXPECT_EQ(echoed_result.bytes_received, 4U);
+    EXPECT_EQ(static_cast<unsigned char>(echoed[0]), 0x11U);
+    EXPECT_EQ(static_cast<unsigned char>(echoed[1]), 0x22U);
+    EXPECT_EQ(static_cast<unsigned char>(echoed[2]), 0x33U);
+    EXPECT_EQ(static_cast<unsigned char>(echoed[3]), 0x44U);
 }
 
 TEST(PipelineTests, Sx1262ReturnsNotInitializedBeforeInit) {

--- a/LoRa/tests/pipeline_tests.cc
+++ b/LoRa/tests/pipeline_tests.cc
@@ -133,6 +133,24 @@ TEST(PipelineTests, Sx127SkeletonMethodsAreCallable) {
     EXPECT_EQ(receive_result.bytes_received, 0U);
 }
 
+TEST(PipelineTests, Sx1262ReturnsNotInitializedBeforeInit) {
+    periph::SX1262Module module;
+    uint8_t buffer[4] = {0, 0, 0, 0};
+
+    EXPECT_EQ(module.transmit(buffer, sizeof(buffer)).status, periph::LoRaStatusCode::NotInitialized);
+    EXPECT_EQ(module.receive(buffer, sizeof(buffer), 50).status,
+              periph::LoRaStatusCode::NotInitialized);
+}
+
+TEST(PipelineTests, Sx127ReturnsNotInitializedBeforeInit) {
+    periph::SX127Module module;
+    uint8_t buffer[4] = {0, 0, 0, 0};
+
+    EXPECT_EQ(module.transmit(buffer, sizeof(buffer)).status, periph::LoRaStatusCode::NotInitialized);
+    EXPECT_EQ(module.receive(buffer, sizeof(buffer), 50).status,
+              periph::LoRaStatusCode::NotInitialized);
+}
+
 TEST(PipelineTests, WritesReceivedPayloadToOutputFile) {
     const std::filesystem::path output_path =
         std::filesystem::temp_directory_path() / "lbr_pipeline_output_test.bin";

--- a/LoRa/tests/test_common.h
+++ b/LoRa/tests/test_common.h
@@ -5,7 +5,8 @@
  * @note Origin: Long Beach Rocketry
  */
 
-#pragma once
+#ifndef LORA_TESTS_TEST_COMMON_H_
+#define LORA_TESTS_TEST_COMMON_H_
 
 #include "cli/args.h"
 
@@ -77,3 +78,5 @@ namespace tests {
         return buffer.str();
     }
 }
+
+#endif  // LORA_TESTS_TEST_COMMON_H_

--- a/README.md
+++ b/README.md
@@ -75,26 +75,24 @@ Single-command build + test (recommended):
 .\build.ps1
 ```
 
+Keyword interface (recommended for all recurring workflows):
+
+```powershell
+.\dev.ps1 build
+```
+
 Build only (skip tests):
 
 ```powershell
-.\build.ps1 -SkipTests
+.\dev.ps1 build-only
 ```
 
 The root script forwards to `tools/build.ps1` and keeps a stable one-command entrypoint.
 
-Manual equivalent:
-
-```powershell
-cmake -S . -B build
-cmake --build build
-ctest --test-dir build --output-on-failure
-```
-
 Sanity checks (when `clang-format` and `clang-tidy` are available in `PATH`):
 
 ```powershell
-cmake --build build --target sanity-check
+.\dev.ps1 sanity
 ```
 
 If either tool is missing from `PATH`, `sanity-check` fails with a clear message.
@@ -102,13 +100,13 @@ If either tool is missing from `PATH`, `sanity-check` fails with a clear message
 Generate API documentation (when `doxygen` is available in `PATH`):
 
 ```powershell
-cmake --build build --target docs
+.\dev.ps1 docs
 ```
 
 Generate PDF API documentation:
 
 ```powershell
-cmake --build build --target docs-pdf
+.\dev.ps1 docs-pdf
 ```
 
 Generated HTML entry point:
@@ -151,7 +149,7 @@ Project source metrics (all production .cc files):
 Generate coverage from repository root:
 
 ```powershell
-cmake --build build-coverage --target coverage
+.\dev.ps1 coverage
 ```
 
 Coverage artifacts are written to:

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Ground software skeleton for the Long Beach Rocketry station, organized under th
 
 The pipeline now consumes telemetry through `ILoRaModule`:
 
-- `init()`
-- `transmit(uint8_t* buf, size_t len)`
-- `receive(uint8_t* buf)`
+- `init() -> LoRaStatusCode`
+- `transmit(const uint8_t* buf, size_t len) -> LoRaTransmitResult`
+- `receive(uint8_t* buf, size_t max_len, uint32_t timeout_ms) -> LoRaReceiveResult`
 
 Because `SDRPipeline` only sees this interface, switching from SX126x to SX127x does not require pipeline logic changes. The only change is module selection in config/CLI.
 
@@ -69,11 +69,53 @@ The CLI option overrides defaults and is validated.
 
 From repository root:
 
+Single-command build + test (recommended):
+
+```powershell
+.\tools\build.ps1
+```
+
+Build only (skip tests):
+
+```powershell
+.\tools\build.ps1 -SkipTests
+```
+
+Manual equivalent:
+
 ```powershell
 cmake -S . -B build
 cmake --build build
 ctest --test-dir build --output-on-failure
 ```
+
+Sanity checks (when `clang-format` and `clang-tidy` are available in `PATH`):
+
+```powershell
+cmake --build build --target sanity-check
+```
+
+If either tool is missing from `PATH`, `sanity-check` fails with a clear message.
+
+Generate API documentation (when `doxygen` is available in `PATH`):
+
+```powershell
+cmake --build build --target docs
+```
+
+Generate PDF API documentation:
+
+```powershell
+cmake --build build --target docs-pdf
+```
+
+Generated HTML entry point:
+
+- `build/docs/doxygen/html/index.html`
+
+Generated PDF:
+
+- `build/docs/doxygen/latex/refman.pdf`
 
 Run app:
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,13 @@ Run app:
 .\build\lbr_ground.exe --lora-module sx127 -v
 ```
 
+Hardware-in-the-loop smoke (real SX backend on bench):
+
+```powershell
+.\build\lbr_hil_runner.exe --module sx1262 --timeout-ms 5000 --min-bytes 1
+.\build\lbr_hil_runner.exe --module sx127 --timeout-ms 5000 --min-bytes 1
+```
+
 ## Coverage
 
 Current score (last run):

--- a/README.md
+++ b/README.md
@@ -1,40 +1,138 @@
-# LBR-26-Ground-Software
+# LoRa Ground Software
 
-Ground software scaffold for the Long Beach Rocketry SDR station.
+Ground software skeleton for the Long Beach Rocketry station, organized under the LoRa root.
 
-Core implementation now lives under `LoRa/`.
+## What This Update Adds
 
-## Documentation
+- A hardware abstraction interface: `periph::ILoRaModule`
+- Two interchangeable backend skeletons:
+  - `periph::SX1262Module`
+  - `periph::SX127Module`
+- `SDRPipeline` now depends on the LoRa abstraction instead of concrete hardware
+- CLI/config support to choose LoRa module at runtime (`sx1262` or `sx127`)
 
-- Overview: `docs/README.md`
-- Build and run: `docs/build-and-run.md`
-- Configuration format: `docs/configuration.md`
-- Architecture: `docs/architecture.md`
-- Tests and coverage: `docs/build-and-run.md`
-- LoRa module details: `LoRa/README.md`
+## Why The Abstraction Helps
 
-## CI/CD
+The pipeline now consumes telemetry through `ILoRaModule`:
 
-GitHub Actions workflow:
-- `.github/workflows/ci.yml`
+- `init()`
+- `transmit(uint8_t* buf, size_t len)`
+- `receive(uint8_t* buf)`
 
-It runs:
-- build + tests (`ctest`) on pushes and pull requests
-- coverage generation (`gcovr`) with artifacts:
-  - `coverage.xml`
-  - `coverage.html`
+Because `SDRPipeline` only sees this interface, switching from SX126x to SX127x does not require pipeline logic changes. The only change is module selection in config/CLI.
 
-## Quick Start
+## Folder Layout
 
-```powershell
-$env:PATH = "C:\msys64\ucrt64\bin;C:\msys64\usr\bin;$env:PATH"
-cmake -S . -B build -G Ninja -DCMAKE_MAKE_PROGRAM=C:\msys64\ucrt64\bin\ninja.exe -DCMAKE_CXX_COMPILER=C:\msys64\ucrt64\bin\g++.exe -DCMAKE_BUILD_TYPE=Release
-cmake --build build -j
-.\build\lbr_ground.exe -c .\config.demo.yaml -v
+```text
+LoRa/
+  include/
+    cli/
+      args.h
+      config.h
+    periph/
+      i_lora_module.h
+      sx1262_module.h
+      sx127_module.h
+    sdr_pipeline.h
+  src/
+    cli/
+      args.cc
+      config.cc
+    periph/
+      sx1262_module.cc
+      sx127_module.cc
+    main.cc
+    sdr_pipeline.cc
+  tests/
+    args_tests.cc
+    config_tests.cc
+    pipeline_tests.cc
+  config.demo.yaml
+  CMakeLists.txt
 ```
 
-For the current layout, prefer:
+## Module Selection
+
+Choose LoRa backend with either:
+
+- CLI: `--lora-module sx1262` or `--lora-module sx127`
+- YAML:
+
+```yaml
+lora:
+  module: "sx1262"
+```
+
+The CLI option overrides defaults and is validated.
+
+## Build And Run
+
+From repository root:
 
 ```powershell
-.\build\LoRa\lbr_ground.exe -c .\LoRa\config.demo.yaml -v
+cmake -S . -B build
+cmake --build build
+ctest --test-dir build --output-on-failure
 ```
+
+Run app:
+
+```powershell
+.\build\lbr_ground.exe --help
+.\build\lbr_ground.exe -c .\LoRa\config.demo.yaml -v
+.\build\lbr_ground.exe --lora-module sx127 -v
+```
+
+## Coverage
+
+Current score (last run):
+
+- Project source aggregate: line 86.65%, functions 100.00%, branches 53.13%
+
+Project source metrics (all production .cc files):
+
+| File | Line | Functions | Branches |
+| --- | ---: | ---: | ---: |
+| args.cc | 90.91% | 100.00% | 78.57% |
+| config.cc | 100.00% | 100.00% | 65.13% |
+| message.cc | 78.98% | 100.00% | 46.05% |
+| ndjson_file.cc | 93.75% | 100.00% | 53.85% |
+| local_tcp_transport.cc | 78.72% | 100.00% | 42.45% |
+| sx1262_module.cc | 100.00% | 100.00% | 0.00% |
+| sx127_module.cc | 100.00% | 100.00% | 0.00% |
+| sdr_pipeline.cc | 100.00% | 100.00% | 71.43% |
+| main.cc | 89.47% | 100.00% | 43.33% |
+| Project aggregate | 86.65% | 100.00% | 53.13% |
+
+Generate coverage from repository root:
+
+```powershell
+cmake --build build-coverage --target coverage
+```
+
+Coverage artifacts are written to:
+
+- [build-coverage/coverage](../build-coverage/coverage)
+
+Main project source reports are available in:
+
+- [build-coverage/coverage/args.cc.gcov](../build-coverage/coverage/args.cc.gcov)
+- [build-coverage/coverage/config.cc.gcov](../build-coverage/coverage/config.cc.gcov)
+- [build-coverage/coverage/sdr_pipeline.cc.gcov](../build-coverage/coverage/sdr_pipeline.cc.gcov)
+- [build-coverage/coverage/main.cc.gcov](../build-coverage/coverage/main.cc.gcov)
+
+## Current Backend State
+
+`SX1262Module` and `SX127Module` are intentionally skeletal backends. They compile and integrate with the pipeline contract but still need hardware-specific SPI/GPIO/radio register logic for production telemetry.
+
+## Connector
+
+The connector contract used between the LoRa side and the consumer side is documented in [docs/connector.md](docs/connector.md).
+
+The implementation lives under [include/connector](include/connector) and [src/connector](src/connector).
+
+Short version:
+
+- Preferred transport: local socket for live data exchange.
+- Fallback transport: file-based replay for offline testing and debugging.
+- The transport layer is intentionally separate from the LoRa module abstraction so the other team can implement it without changing the pipeline contract.

--- a/README.md
+++ b/README.md
@@ -72,14 +72,16 @@ From repository root:
 Single-command build + test (recommended):
 
 ```powershell
-.\tools\build.ps1
+.\build.ps1
 ```
 
 Build only (skip tests):
 
 ```powershell
-.\tools\build.ps1 -SkipTests
+.\build.ps1 -SkipTests
 ```
+
+The root script forwards to `tools/build.ps1` and keeps a stable one-command entrypoint.
 
 Manual equivalent:
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,9 @@
+param(
+    [string]$Preset = "windows-ucrt-ninja",
+    [string]$BuildTarget = "lbr_tests",
+    [switch]$SkipTests
+)
+
+$scriptPath = Join-Path $PSScriptRoot "tools\build.ps1"
+& $scriptPath -Preset $Preset -BuildTarget $BuildTarget -SkipTests:$SkipTests
+exit $LASTEXITCODE

--- a/dev.ps1
+++ b/dev.ps1
@@ -1,0 +1,8 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$PassThroughArgs
+)
+
+$scriptPath = Join-Path $PSScriptRoot "tools\dev.ps1"
+& $scriptPath @PassThroughArgs
+exit $LASTEXITCODE

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1,0 +1,42 @@
+PROJECT_NAME           = "LBR-26 Ground Software"
+PROJECT_BRIEF          = "Long Beach Rocketry ground software"
+PROJECT_NUMBER         = "0.1.0"
+OUTPUT_DIRECTORY       = "@LBR_DOXYGEN_OUTPUT_DIR@"
+CREATE_SUBDIRS         = NO
+ALLOW_UNICODE_NAMES    = YES
+OUTPUT_LANGUAGE        = English
+
+INPUT                  = "@LBR_DOXYGEN_INPUT_DIR@/README.md" \
+                         "@LBR_DOXYGEN_INPUT_DIR@/docs" \
+                         "@LBR_DOXYGEN_INPUT_DIR@/LoRa/include" \
+                         "@LBR_DOXYGEN_INPUT_DIR@/LoRa/src" \
+                         "@LBR_DOXYGEN_INPUT_DIR@/LoRa/README.md" \
+                         "@LBR_DOXYGEN_INPUT_DIR@/LoRa/docs"
+FILE_PATTERNS          = *.h *.cc *.md
+RECURSIVE              = YES
+EXCLUDE                = "@LBR_DOXYGEN_INPUT_DIR@/build" \
+                         "@LBR_DOXYGEN_INPUT_DIR@/build-*"
+
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = NO
+EXTRACT_STATIC         = NO
+EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_ANON_NSPACES   = YES
+
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+GENERATE_TREEVIEW      = YES
+FULL_SIDEBAR           = YES
+
+GENERATE_LATEX         = YES
+GENERATE_XML           = NO
+
+USE_MDFILE_AS_MAINPAGE = "@LBR_DOXYGEN_INPUT_DIR@/README.md"
+MARKDOWN_SUPPORT       = YES
+AUTOLINK_SUPPORT       = YES
+INLINE_INHERITED_MEMB  = YES
+SORT_MEMBER_DOCS       = YES
+QUIET                  = NO
+WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_DOC_ERROR      = YES
+WARN_NO_PARAMDOC       = NO

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -15,29 +15,19 @@ GoogleTest is also fetched automatically when `BUILD_TESTING=ON` (default).
 Recommended single command from repository root:
 
 ```powershell
-.\build.ps1
+.\dev.ps1 build
 ```
 
 Build only (skip tests):
 
 ```powershell
-.\build.ps1 -SkipTests
-```
-
-`build.ps1` forwards all arguments to `tools/build.ps1`.
-
-Equivalent manual commands:
-
-```powershell
-$env:PATH = "C:\msys64\ucrt64\bin;C:\msys64\usr\bin;$env:PATH"
-cmake -S . -B build -G Ninja -DCMAKE_MAKE_PROGRAM=C:\msys64\ucrt64\bin\ninja.exe -DCMAKE_CXX_COMPILER=C:\msys64\ucrt64\bin\g++.exe -DCMAKE_BUILD_TYPE=Release
-cmake --build build -j
+.\dev.ps1 build-only
 ```
 
 ## Test
 
 ```powershell
-ctest --test-dir build --output-on-failure
+.\dev.ps1 test
 ```
 
 This runs:
@@ -49,9 +39,7 @@ This runs:
 When `clang-format` and `clang-tidy` are installed in `PATH`, CMake exposes sanity targets:
 
 ```powershell
-cmake --build build --target clang-format-check
-cmake --build build --target clang-tidy
-cmake --build build --target sanity-check
+.\dev.ps1 sanity
 ```
 
 If either tool is missing from `PATH`, the corresponding target fails with an explicit message.
@@ -61,7 +49,7 @@ If either tool is missing from `PATH`, the corresponding target fails with an ex
 Generate API documentation:
 
 ```powershell
-cmake --build build --target docs
+.\dev.ps1 docs
 ```
 
 Generated HTML entry point:
@@ -71,7 +59,7 @@ Generated HTML entry point:
 Generate PDF documentation:
 
 ```powershell
-cmake --build build --target docs-pdf
+.\dev.ps1 docs-pdf
 ```
 
 Generated PDF:
@@ -83,14 +71,13 @@ If `doxygen` is missing from `PATH`, the target fails with an explicit message.
 Optional compile-time tidy enforcement:
 
 ```powershell
-cmake -S . -B build -DLBR_ENABLE_CLANG_TIDY=ON
-cmake --build build -j
+.\dev.ps1 tidy
 ```
 
 Automatic formatting target:
 
 ```powershell
-cmake --build build --target clang-format
+.\dev.ps1 format
 ```
 
 ## Coverage
@@ -98,10 +85,7 @@ cmake --build build --target clang-format
 Build with coverage instrumentation:
 
 ```powershell
-$env:PATH = "C:\msys64\ucrt64\bin;C:\msys64\usr\bin;$env:PATH"
-cmake -S . -B build-coverage -G Ninja -DCMAKE_MAKE_PROGRAM=C:\msys64\ucrt64\bin\ninja.exe -DCMAKE_CXX_COMPILER=C:\msys64\ucrt64\bin\g++.exe -DCMAKE_BUILD_TYPE=Debug -DLBR_ENABLE_COVERAGE=ON
-cmake --build build-coverage -j
-cmake --build build-coverage --target coverage
+.\dev.ps1 coverage
 ```
 
 Coverage artifacts are generated in:

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -12,6 +12,20 @@ GoogleTest is also fetched automatically when `BUILD_TESTING=ON` (default).
 
 ## Build (PowerShell)
 
+Recommended single command from repository root:
+
+```powershell
+.\tools\build.ps1
+```
+
+Build only (skip tests):
+
+```powershell
+.\tools\build.ps1 -SkipTests
+```
+
+Equivalent manual commands:
+
 ```powershell
 $env:PATH = "C:\msys64\ucrt64\bin;C:\msys64\usr\bin;$env:PATH"
 cmake -S . -B build -G Ninja -DCMAKE_MAKE_PROGRAM=C:\msys64\ucrt64\bin\ninja.exe -DCMAKE_CXX_COMPILER=C:\msys64\ucrt64\bin\g++.exe -DCMAKE_BUILD_TYPE=Release
@@ -27,6 +41,55 @@ ctest --test-dir build --output-on-failure
 This runs:
 - unit test binary (`lbr_tests`, based on GoogleTest)
 - integration checks on `lbr_ground` (`--help`, demo config, missing config failure path)
+
+## Clang Sanity Check
+
+When `clang-format` and `clang-tidy` are installed in `PATH`, CMake exposes sanity targets:
+
+```powershell
+cmake --build build --target clang-format-check
+cmake --build build --target clang-tidy
+cmake --build build --target sanity-check
+```
+
+If either tool is missing from `PATH`, the corresponding target fails with an explicit message.
+
+## Doxygen Documentation
+
+Generate API documentation:
+
+```powershell
+cmake --build build --target docs
+```
+
+Generated HTML entry point:
+
+- `build/docs/doxygen/html/index.html`
+
+Generate PDF documentation:
+
+```powershell
+cmake --build build --target docs-pdf
+```
+
+Generated PDF:
+
+- `build/docs/doxygen/latex/refman.pdf`
+
+If `doxygen` is missing from `PATH`, the target fails with an explicit message.
+
+Optional compile-time tidy enforcement:
+
+```powershell
+cmake -S . -B build -DLBR_ENABLE_CLANG_TIDY=ON
+cmake --build build -j
+```
+
+Automatic formatting target:
+
+```powershell
+cmake --build build --target clang-format
+```
 
 ## Coverage
 

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -15,14 +15,16 @@ GoogleTest is also fetched automatically when `BUILD_TESTING=ON` (default).
 Recommended single command from repository root:
 
 ```powershell
-.\tools\build.ps1
+.\build.ps1
 ```
 
 Build only (skip tests):
 
 ```powershell
-.\tools\build.ps1 -SkipTests
+.\build.ps1 -SkipTests
 ```
+
+`build.ps1` forwards all arguments to `tools/build.ps1`.
 
 Equivalent manual commands:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ sdr:
 
 pipeline:
   verbose: true
+  interpret_telemetry: true
   output_path: "output/frame.bin"
 ```
 
@@ -32,6 +33,7 @@ pipeline:
 ### `pipeline`
 
 - `verbose` (`bool`)
+- `interpret_telemetry` (`bool`)
 - `output_path` (`string`)
 
 ## Defaults
@@ -43,6 +45,7 @@ If a key is missing, defaults are used:
 - `sdr.center_freq_hz = 433920000`
 - `sdr.gain_db = 30`
 - `pipeline.verbose = false`
+- `pipeline.interpret_telemetry = true`
 - `pipeline.output_path = "output/frame.bin"`
 
 ## Validation Rules

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -1,0 +1,40 @@
+param(
+    [string]$Preset = "windows-ucrt-ninja",
+    [string]$BuildTarget = "lbr_tests",
+    [switch]$SkipTests
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][scriptblock]$Action
+    )
+
+    Write-Host "==> $Name" -ForegroundColor Cyan
+    & $Action
+}
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Set-Location $repoRoot
+
+# Keep MSYS2 runtime DLLs ahead of other toolchains in PATH.
+$env:PATH = "C:\msys64\ucrt64\bin;C:\msys64\usr\bin;$env:PATH"
+
+Invoke-Step -Name "Configure preset '$Preset'" -Action {
+    cmake --preset $Preset
+}
+
+Invoke-Step -Name "Build target '$BuildTarget'" -Action {
+    cmake --build --preset $Preset --target $BuildTarget
+}
+
+if (-not $SkipTests) {
+    Invoke-Step -Name "Run tests preset '$Preset'" -Action {
+        ctest --preset $Preset
+    }
+}
+
+Write-Host "Build workflow completed." -ForegroundColor Green

--- a/tools/dev.ps1
+++ b/tools/dev.ps1
@@ -1,0 +1,133 @@
+param(
+    [ValidateSet("help", "build", "build-only", "test", "sanity", "format", "tidy", "docs", "docs-pdf", "coverage", "proto", "nanopb")]
+    [string]$Command = "help"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Set-Location $repoRoot
+
+# Keep MSYS2 runtime DLLs ahead of other toolchains.
+$env:PATH = "C:\msys64\ucrt64\bin;C:\msys64\usr\bin;$env:PATH"
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][scriptblock]$Action
+    )
+
+    Write-Host "==> $Name" -ForegroundColor Cyan
+    & $Action
+}
+
+function Show-Help {
+    Write-Host "Usage: .\dev.ps1 <keyword>" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "Keywords:" -ForegroundColor Yellow
+    Write-Host "  help        Show this help"
+    Write-Host "  build       Configure + build lbr_tests + run tests"
+    Write-Host "  build-only  Configure + build lbr_tests (no tests)"
+    Write-Host "  test        Run test preset"
+    Write-Host "  sanity      Run clang-format-check + clang-tidy"
+    Write-Host "  format      Run clang-format"
+    Write-Host "  tidy        Run clang-tidy"
+    Write-Host "  docs        Build Doxygen HTML"
+    Write-Host "  docs-pdf    Build Doxygen PDF"
+    Write-Host "  coverage    Configure and build coverage target"
+    Write-Host "  proto       Generate C++ protobuf sources"
+    Write-Host "  nanopb      Generate nanopb sources"
+}
+
+switch ($Command) {
+    "help" {
+        Show-Help
+    }
+
+    "build" {
+        & (Join-Path $repoRoot "build.ps1")
+        exit $LASTEXITCODE
+    }
+
+    "build-only" {
+        & (Join-Path $repoRoot "build.ps1") -SkipTests
+        exit $LASTEXITCODE
+    }
+
+    "test" {
+        Invoke-Step -Name "Run tests preset 'windows-ucrt-ninja'" -Action {
+            ctest --preset windows-ucrt-ninja
+        }
+    }
+
+    "sanity" {
+        Invoke-Step -Name "Run sanity-check target" -Action {
+            cmake --build --preset windows-ucrt-ninja --target sanity-check
+        }
+    }
+
+    "format" {
+        Invoke-Step -Name "Run clang-format target" -Action {
+            cmake --build --preset windows-ucrt-ninja --target clang-format
+        }
+    }
+
+    "tidy" {
+        Invoke-Step -Name "Run clang-tidy target" -Action {
+            cmake --build --preset windows-ucrt-ninja --target clang-tidy
+        }
+    }
+
+    "docs" {
+        Invoke-Step -Name "Build docs target" -Action {
+            cmake --build --preset windows-ucrt-ninja --target docs
+        }
+    }
+
+    "docs-pdf" {
+        Invoke-Step -Name "Build docs-pdf target" -Action {
+            cmake --build --preset windows-ucrt-ninja --target docs-pdf
+        }
+    }
+
+    "coverage" {
+        Invoke-Step -Name "Configure coverage build" -Action {
+            cmake -S . -B build-coverage -G Ninja -DCMAKE_MAKE_PROGRAM=C:/msys64/ucrt64/bin/ninja.exe -DCMAKE_CXX_COMPILER=C:/msys64/ucrt64/bin/g++.exe -DCMAKE_BUILD_TYPE=Debug -DLBR_ENABLE_COVERAGE=ON
+        }
+
+        Invoke-Step -Name "Build coverage artifacts" -Action {
+            cmake --build build-coverage -j
+        }
+
+        Invoke-Step -Name "Run coverage target" -Action {
+            cmake --build build-coverage --target coverage
+        }
+    }
+
+    "proto" {
+        Invoke-Step -Name "Configure build with protobuf codegen" -Action {
+            cmake -S . -B build -G Ninja -DCMAKE_MAKE_PROGRAM=C:/msys64/ucrt64/bin/ninja.exe -DCMAKE_CXX_COMPILER=C:/msys64/ucrt64/bin/g++.exe -DCMAKE_BUILD_TYPE=Release -DLBR_ENABLE_PROTOBUF_CODEGEN=ON
+        }
+
+        Invoke-Step -Name "Generate connector protobuf C++ sources" -Action {
+            cmake --build build --target connector_proto_codegen
+        }
+    }
+
+    "nanopb" {
+        Invoke-Step -Name "Configure build with protobuf codegen" -Action {
+            cmake -S . -B build -G Ninja -DCMAKE_MAKE_PROGRAM=C:/msys64/ucrt64/bin/ninja.exe -DCMAKE_CXX_COMPILER=C:/msys64/ucrt64/bin/g++.exe -DCMAKE_BUILD_TYPE=Release -DLBR_ENABLE_PROTOBUF_CODEGEN=ON
+        }
+
+        Invoke-Step -Name "Generate connector nanopb sources" -Action {
+            cmake --build build --target connector_nanopb_codegen
+        }
+    }
+
+    default {
+        throw "Unknown keyword: $Command"
+    }
+}
+
+Write-Host "Done." -ForegroundColor Green

--- a/tools/dev.ps1
+++ b/tools/dev.ps1
@@ -1,5 +1,5 @@
 param(
-    [ValidateSet("help", "build", "build-only", "test", "sanity", "format", "tidy", "docs", "docs-pdf", "coverage", "proto", "nanopb")]
+    [ValidateSet("help", "build", "build-only", "test", "sanity", "format", "tidy", "docs", "docs-pdf", "coverage", "proto", "nanopb", "hil")]
     [string]$Command = "help"
 )
 
@@ -38,6 +38,7 @@ function Show-Help {
     Write-Host "  coverage    Configure and build coverage target"
     Write-Host "  proto       Generate C++ protobuf sources"
     Write-Host "  nanopb      Generate nanopb sources"
+    Write-Host "  hil         Build HIL runner and print real bench command"
 }
 
 switch ($Command) {
@@ -123,6 +124,20 @@ switch ($Command) {
         Invoke-Step -Name "Generate connector nanopb sources" -Action {
             cmake --build build --target connector_nanopb_codegen
         }
+    }
+
+    "hil" {
+        Invoke-Step -Name "Configure preset 'windows-ucrt-ninja'" -Action {
+            cmake --preset windows-ucrt-ninja
+        }
+
+        Invoke-Step -Name "Build HIL runner" -Action {
+            cmake --build --preset windows-ucrt-ninja --target lbr_hil_runner
+        }
+
+        Write-Host "Run on bench:" -ForegroundColor Yellow
+        Write-Host "  .\\build\\lbr_hil_runner.exe --module sx1262 --timeout-ms 5000 --min-bytes 1"
+        Write-Host "  .\\build\\lbr_hil_runner.exe --module sx127 --timeout-ms 5000 --min-bytes 1"
     }
 
     default {


### PR DESCRIPTION
## Summary
- Implements: refactor(headers): replace pragma once with include guards
- Branch: pr/5bc08de-refactor-headers-replace-pragma-once-wit
- Commit: 5bc08de

## Scope
- This PR contains a single stacked commit from lf-test-ci.
- No unrelated changes are included.

## Validation
- Validation status follows the commit's original test/build checks in the stack workflow.

## Notes
- This PR is part of a sequenced series and is intentionally focused.
