### PR TITLE
ci: validate zeromq/protobuf options and add windows smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,138 @@
+name: CI/CD
+
+on:
+  push:
+    branches:
+      - main
+      - lf-*
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build
+
+      - name: Configure
+        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build -j
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    needs: tests
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build
+
+      - name: Install gcovr
+        run: python3 -m pip install --upgrade gcovr
+
+      - name: Configure (coverage)
+        run: cmake -S . -B build-coverage -G Ninja -DCMAKE_BUILD_TYPE=Debug -DLBR_ENABLE_COVERAGE=ON
+
+      - name: Build (coverage)
+        run: cmake --build build-coverage -j
+
+      - name: Run tests (coverage)
+        run: ctest --test-dir build-coverage --output-on-failure
+
+      - name: Generate coverage reports
+        run: |
+          gcovr -r . \
+            --filter '^.*/src/' \
+            --exclude '^.*/build.*/_deps/' \
+            --xml-pretty -o build-coverage/coverage.xml \
+            --html-details -o build-coverage/coverage.html
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            build-coverage/coverage.xml
+            build-coverage/coverage.html
+
+  feature-options:
+    name: Feature Options (ZeroMQ + Protobuf)
+    runs-on: ubuntu-latest
+    needs: tests
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install build tools and optional deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build libzmq3-dev protobuf-compiler python3-pip
+          python3 -m pip install --user nanopb
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Configure with optional features
+        run: cmake -S . -B build-features -G Ninja -DCMAKE_BUILD_TYPE=Release -DLBR_ENABLE_ZEROMQ=ON -DLBR_ENABLE_PROTOBUF_CODEGEN=ON
+
+      - name: Build tests with optional features
+        run: cmake --build build-features -j --target lbr_tests
+
+      - name: Generate protobuf code
+        run: cmake --build build-features --target connector_proto_codegen
+
+      - name: Generate nanopb code
+        run: cmake --build build-features --target connector_nanopb_codegen
+
+      - name: Run ZeroMQ connector test
+        run: ctest --test-dir build-features -R ConnectorTests.LocalZmqTransportPubSubExchange --output-on-failure
+
+  windows-smoke:
+    name: Windows UCRT Smoke
+    runs-on: windows-latest
+    needs: tests
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup MSYS2 UCRT64
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-ninja
+            mingw-w64-ucrt-x86_64-cmake
+
+      - name: Configure
+        shell: powershell
+        run: cmake --preset windows-ucrt-ninja
+
+      - name: Build
+        shell: powershell
+        run: cmake --build --preset windows-ucrt-ninja --target lbr_tests
+
+      - name: Test
+        shell: powershell
+        run: ctest --preset windows-ucrt-ninja

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,7 +14,6 @@
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "CMAKE_CXX_COMPILER": "C:/msys64/ucrt64/bin/g++.exe",
-        "CMAKE_MAKE_PROGRAM": "C:/msys64/ucrt64/bin/ninja.exe",
         "CMAKE_BUILD_TYPE": "Release"
       },
       "environment": {

--- a/LoRa/CMakeLists.txt
+++ b/LoRa/CMakeLists.txt
@@ -248,32 +248,33 @@ if(LBR_ENABLE_PROTOBUF_CODEGEN)
 
     set(LBR_PROTO_SRC ${CMAKE_CURRENT_SOURCE_DIR}/docs/connector-message.proto)
     set(LBR_PROTO_OPTIONS ${CMAKE_CURRENT_SOURCE_DIR}/docs/connector-message.nanopb.options)
-    set(LBR_PROTO_GEN_DIR ${CMAKE_BINARY_DIR}/generated/proto)
+    set(LBR_PROTO_CPP_GEN_DIR ${CMAKE_BINARY_DIR}/generated/proto/cpp)
+    set(LBR_PROTO_NANOPB_GEN_DIR ${CMAKE_BINARY_DIR}/generated/proto/nanopb)
 
     add_custom_target(connector_proto_codegen
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${LBR_PROTO_GEN_DIR}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${LBR_PROTO_CPP_GEN_DIR}
         COMMAND ${PROTOC_EXECUTABLE}
             --proto_path=${CMAKE_CURRENT_SOURCE_DIR}/docs
-            --cpp_out=${LBR_PROTO_GEN_DIR}
+            --cpp_out=${LBR_PROTO_CPP_GEN_DIR}
             ${LBR_PROTO_SRC}
         BYPRODUCTS
-            ${LBR_PROTO_GEN_DIR}/connector-message.pb.cc
-            ${LBR_PROTO_GEN_DIR}/connector-message.pb.h
+            ${LBR_PROTO_CPP_GEN_DIR}/connector-message.pb.cc
+            ${LBR_PROTO_CPP_GEN_DIR}/connector-message.pb.h
         COMMENT "Generating C++ protobuf sources for connector-message.proto"
         VERBATIM
     )
 
     add_custom_target(connector_nanopb_codegen
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${LBR_PROTO_GEN_DIR}
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LBR_PROTO_OPTIONS} ${LBR_PROTO_GEN_DIR}/connector-message.options
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${LBR_PROTO_NANOPB_GEN_DIR}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LBR_PROTO_OPTIONS} ${LBR_PROTO_NANOPB_GEN_DIR}/connector-message.options
         COMMAND ${PROTOC_EXECUTABLE}
             --proto_path=${CMAKE_CURRENT_SOURCE_DIR}/docs
             --plugin=protoc-gen-nanopb=${PROTOC_GEN_NANOPB_EXECUTABLE}
-            --nanopb_out=${LBR_PROTO_GEN_DIR}
+            --nanopb_out=${LBR_PROTO_NANOPB_GEN_DIR}
             ${LBR_PROTO_SRC}
         BYPRODUCTS
-            ${LBR_PROTO_GEN_DIR}/connector-message.pb.c
-            ${LBR_PROTO_GEN_DIR}/connector-message.pb.h
+            ${LBR_PROTO_NANOPB_GEN_DIR}/connector-message.pb.c
+            ${LBR_PROTO_NANOPB_GEN_DIR}/connector-message.pb.h
         COMMENT "Generating nanopb sources for connector-message.proto"
         VERBATIM
     )

--- a/LoRa/docs/protobuf-nanopb.md
+++ b/LoRa/docs/protobuf-nanopb.md
@@ -28,7 +28,8 @@ Generate nanopb sources (embedded side):
 
 Generated files are written to:
 
-- `build/generated/proto`
+- `build/generated/proto/cpp`
+- `build/generated/proto/nanopb`
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Implements: ci: validate zeromq/protobuf options and add windows smoke
- Branch: pr/7ddd5a5-ci-validate-zeromq-protobuf-options-and
- Commit: 7ddd5a5

## Scope
- This PR contains a single stacked commit from lf-test-ci.
- No unrelated changes are included.

## Validation
- Validation status follows the commit's original test/build checks in the stack workflow.

## Notes
- This PR is part of a sequenced series and is intentionally focused.
