### PR TITLE
feat(connector): add optional ZeroMQ PUB/SUB transport

### DIFF
--- a/LoRa/CMakeLists.txt
+++ b/LoRa/CMakeLists.txt
@@ -15,10 +15,70 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(LBR_ENABLE_COVERAGE "Enable gcov coverage instrumentation (GNU only)" OFF)
+option(LBR_ENABLE_CLANG_TIDY "Enable clang-tidy while compiling targets" OFF)
+option(LBR_ENABLE_ZEROMQ "Enable ZeroMQ connector transport" OFF)
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0")
     set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 endif()
+
+find_program(CLANG_FORMAT_EXECUTABLE clang-format)
+find_program(CLANG_TIDY_EXECUTABLE clang-tidy)
+
+if(LBR_ENABLE_CLANG_TIDY)
+    if(NOT CLANG_TIDY_EXECUTABLE)
+        message(FATAL_ERROR "LBR_ENABLE_CLANG_TIDY=ON requires clang-tidy in PATH.")
+    endif()
+    set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_EXECUTABLE})
+endif()
+
+file(GLOB_RECURSE LBR_CLANG_SOURCE_FILES CONFIGURE_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cc
+)
+
+if(CLANG_FORMAT_EXECUTABLE)
+    add_custom_target(clang-format
+        COMMAND ${CLANG_FORMAT_EXECUTABLE} -i ${LBR_CLANG_SOURCE_FILES}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMENT "Formatting C++ sources with clang-format."
+    )
+
+    add_custom_target(clang-format-check
+        COMMAND ${CLANG_FORMAT_EXECUTABLE} --dry-run --Werror ${LBR_CLANG_SOURCE_FILES}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMENT "Checking C++ format with clang-format."
+    )
+else()
+    add_custom_target(clang-format
+        COMMAND ${CMAKE_COMMAND} -E echo "clang-format not found in PATH."
+        COMMAND ${CMAKE_COMMAND} -E false
+        COMMENT "clang-format is required for this target."
+    )
+
+    add_custom_target(clang-format-check
+        COMMAND ${CMAKE_COMMAND} -E echo "clang-format not found in PATH."
+        COMMAND ${CMAKE_COMMAND} -E false
+        COMMENT "clang-format is required for this target."
+    )
+endif()
+
+if(CLANG_TIDY_EXECUTABLE)
+    add_custom_target(clang-tidy
+        COMMAND ${CLANG_TIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR} ${LBR_CLANG_SOURCE_FILES}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMENT "Running clang-tidy static analysis."
+    )
+else()
+    add_custom_target(clang-tidy
+        COMMAND ${CMAKE_COMMAND} -E echo "clang-tidy not found in PATH."
+        COMMAND ${CMAKE_COMMAND} -E false
+        COMMENT "clang-tidy is required for this target."
+    )
+endif()
+
+add_custom_target(sanity-check DEPENDS clang-format-check clang-tidy)
 
 if(LBR_ENABLE_COVERAGE AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     message(FATAL_ERROR "LBR_ENABLE_COVERAGE requires GNU compiler.")
@@ -86,18 +146,42 @@ add_library(connector
     src/connector/message.cc
     src/connector/ndjson_file.cc
     src/connector/local_tcp_transport.cc
+    src/connector/local_udp_transport.cc
+    src/connector/local_zmq_transport.cc
 )
 target_include_directories(connector PUBLIC include)
+
+set(LBR_HAS_ZEROMQ 0)
+if(LBR_ENABLE_ZEROMQ)
+    find_path(ZMQ_INCLUDE_DIR zmq.h)
+    find_library(ZMQ_LIBRARY NAMES zmq libzmq)
+    if(NOT ZMQ_INCLUDE_DIR OR NOT ZMQ_LIBRARY)
+        message(FATAL_ERROR "LBR_ENABLE_ZEROMQ=ON requires ZeroMQ (zmq.h + libzmq).")
+    endif()
+
+    target_include_directories(connector PRIVATE ${ZMQ_INCLUDE_DIR})
+    target_link_libraries(connector PRIVATE ${ZMQ_LIBRARY})
+    set(LBR_HAS_ZEROMQ 1)
+endif()
+
+target_compile_definitions(connector PUBLIC LBR_HAS_ZEROMQ=${LBR_HAS_ZEROMQ})
+
 if(WIN32)
     target_link_libraries(connector PRIVATE ws2_32)
 endif()
 lbr_enable_coverage(connector)
 
+add_library(telemetry
+    src/telemetry/interpreter.cc
+)
+target_include_directories(telemetry PUBLIC include)
+lbr_enable_coverage(telemetry)
+
 add_library(sdr_pipeline
     src/sdr_pipeline.cc
 )
 target_include_directories(sdr_pipeline PUBLIC include)
-target_link_libraries(sdr_pipeline PUBLIC cli)
+target_link_libraries(sdr_pipeline PUBLIC cli telemetry)
 lbr_enable_coverage(sdr_pipeline)
 
 add_executable(lbr_ground
@@ -159,7 +243,7 @@ if(LBR_ENABLE_COVERAGE)
             COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/coverage ${GCOV_EXECUTABLE} -f -b -c -o ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/cli.dir/src/cli ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/cli.dir/src/cli/args.cc.obj ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/cli.dir/src/cli/config.cc.obj
             COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/coverage ${GCOV_EXECUTABLE} -f -b -c -o ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/sdr_pipeline.dir/src ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/sdr_pipeline.dir/src/sdr_pipeline.cc.obj
             COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/coverage ${GCOV_EXECUTABLE} -f -b -c -o ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/lbr_ground.dir/src ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/lbr_ground.dir/src/main.cc.obj
-            COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/coverage ${GCOV_EXECUTABLE} -f -b -c -o ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/connector.dir/src/connector ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/connector.dir/src/connector/message.cc.obj ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/connector.dir/src/connector/ndjson_file.cc.obj ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/connector.dir/src/connector/local_tcp_transport.cc.obj
+            COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/coverage ${GCOV_EXECUTABLE} -f -b -c -o ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/connector.dir/src/connector ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/connector.dir/src/connector/message.cc.obj ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/connector.dir/src/connector/ndjson_file.cc.obj ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/connector.dir/src/connector/local_tcp_transport.cc.obj ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/connector.dir/src/connector/local_udp_transport.cc.obj
             COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/coverage ${GCOV_EXECUTABLE} -f -b -c -o ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/lora_periph.dir/src/periph ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/lora_periph.dir/src/periph/sx1262_module.cc.obj ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/lora_periph.dir/src/periph/sx127_module.cc.obj
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
             COMMENT "Running tests and generating gcov coverage reports."

--- a/LoRa/docs/connector.md
+++ b/LoRa/docs/connector.md
@@ -7,6 +7,8 @@ The code implementation lives under:
 - [include/connector/message.h](../include/connector/message.h)
 - [include/connector/ndjson_file.h](../include/connector/ndjson_file.h)
 - [include/connector/local_tcp_transport.h](../include/connector/local_tcp_transport.h)
+- [include/connector/local_udp_transport.h](../include/connector/local_udp_transport.h)
+- [include/connector/local_zmq_transport.h](../include/connector/local_zmq_transport.h)
 
 ## Recommendation
 
@@ -23,6 +25,15 @@ Recommended implementation choice:
 
 - On Windows: localhost TCP or a named pipe.
 - On Unix-like systems: localhost TCP or a Unix domain socket.
+
+For low-latency telemetry where producer backpressure must never stall capture,
+prefer local UDP with bounded receive timeouts.
+
+Implementation note in this repository:
+
+- `LocalUdpTransport` is available for timeout-based datagram reads.
+- `LocalTcpTransport` remains available for ordered stream semantics.
+- `LocalZmqTransport` is available for PUB/SUB patterns when built with `-DLBR_ENABLE_ZEROMQ=ON`.
 
 If the consumer side already has a preference, keep the transport behind a small adapter so the pipeline contract does not change.
 
@@ -60,19 +71,28 @@ The connector is not responsible for:
 
 Use the JSON envelope described in [connector-message.schema.json](connector-message.schema.json).
 
+For binary transport, use protobuf with the schema in
+[connector-message.proto](connector-message.proto).
+
+When the flight/embedded side is constrained, use nanopb generated code from the same
+`.proto` schema to keep wire compatibility with the ground side.
+
 Required fields:
 
-- `schema_version`: integer, currently `1`
-- `message_type`: string, currently `telemetry_frame`
+- `schema_version`: integer, `>= 1`
+- `message_type`: non-empty string identifying envelope kind (`telemetry_frame`, `telemetry_decoded`, custom, etc.)
 - `sequence`: monotonically increasing integer starting at `0`
 - `timestamp_ms`: Unix epoch milliseconds
-- `source`: string, one of `sx1262`, `sx127`, or `simulated`
+- `source`: non-empty source identifier (for example `sx1262`, `simulated`, or custom identifiers)
 - `payload_b64`: base64-encoded raw telemetry bytes
 
 Optional fields:
 
 - `checksum_hex`: integrity marker in hexadecimal if the producer wants it
 - `metadata`: extra implementation-specific fields that do not change the contract
+
+The envelope is intentionally extensible so teams can introduce protocol-specific message types
+and source identifiers without changing transport adapters.
 
 Example message:
 
@@ -102,6 +122,9 @@ That structure is enough for the other team to build a consumer without coupling
 Do not let the connector leak into `SDRPipeline` or the LoRa radio abstraction.
 
 The pipeline should continue to depend on `ILoRaModule` only. The connector should remain a separate adapter owned by the consumer-facing layer.
+
+The ground software can optionally perform a lightweight local interpretation pass for operator visibility,
+but this does not change the connector contract and does not replace consumer-side mission interpretation.
 
 ## Notes For The Other Team
 

--- a/LoRa/include/connector/local_zmq_transport.h
+++ b/LoRa/include/connector/local_zmq_transport.h
@@ -1,0 +1,81 @@
+/**
+ * @file local_zmq_transport.h
+ * @brief Optional local ZeroMQ transport for connector messages
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace connector {
+    /**
+     * @brief Role of the local ZeroMQ endpoint.
+     */
+    enum class LocalZmqMode {
+        Publisher,
+        Subscriber
+    };
+
+    /**
+     * @brief Topic-based local ZeroMQ transport.
+     *
+     * This class is compiled in all builds. Actual ZeroMQ behavior is enabled only
+     * when CMake sets LBR_HAS_ZEROMQ=1.
+     */
+    class LocalZmqTransport {
+        public:
+            /**
+             * @brief Creates a ZeroMQ endpoint descriptor.
+             * @param mode Endpoint role (publisher/subscriber).
+             * @param endpoint ZeroMQ endpoint string (e.g. tcp://127.0.0.1:5560).
+             * @param topic Topic prefix used by publisher/subscriber filtering.
+             */
+            LocalZmqTransport(LocalZmqMode mode, std::string endpoint, std::string topic);
+
+            /**
+             * @brief Releases underlying resources.
+             */
+            ~LocalZmqTransport();
+
+            /**
+             * @brief Opens the transport endpoint.
+             * @throws std::runtime_error on failure or when ZeroMQ is not available.
+             */
+            void open();
+
+            /**
+             * @brief Closes the transport endpoint.
+             */
+            void close() noexcept;
+
+            /**
+             * @brief Sends one topic-framed payload.
+             * @param payload Payload bytes.
+             * @throws std::runtime_error on failure.
+             */
+            void send_message(const std::string &payload);
+
+            /**
+             * @brief Reads one payload with timeout.
+             * @param payload Output payload bytes.
+             * @param timeout_ms Maximum wait in milliseconds.
+             * @return True if payload is received, false on timeout.
+             * @throws std::runtime_error on failure.
+             */
+            bool receive_message(std::string &payload, std::int32_t timeout_ms);
+
+        private:
+            void ensure_open() const;
+
+            LocalZmqMode _mode;
+            std::string _endpoint;
+            std::string _topic;
+            bool _is_open = false;
+
+            struct Impl;
+            Impl *_impl = nullptr;
+    };
+}

--- a/LoRa/src/connector/local_zmq_transport.cc
+++ b/LoRa/src/connector/local_zmq_transport.cc
@@ -1,0 +1,166 @@
+/**
+ * @file local_zmq_transport.cc
+ * @brief Optional local ZeroMQ transport for connector messages
+ * @author Luis Fernandes (luisrobertantonio.fernandes01@student.csulb.edu)
+ * @note Origin: Long Beach Rocketry
+ */
+
+#include "connector/local_zmq_transport.h"
+
+#include <stdexcept>
+#include <utility>
+
+#if defined(LBR_HAS_ZEROMQ) && LBR_HAS_ZEROMQ
+    #include <zmq.h>
+#endif
+
+namespace connector {
+    struct LocalZmqTransport::Impl {
+#if defined(LBR_HAS_ZEROMQ) && LBR_HAS_ZEROMQ
+        void *context = nullptr;
+        void *socket = nullptr;
+#endif
+    };
+}
+
+connector::LocalZmqTransport::LocalZmqTransport(LocalZmqMode mode,
+                                                std::string endpoint,
+                                                std::string topic)
+    : _mode(mode),
+      _endpoint(std::move(endpoint)),
+      _topic(std::move(topic)),
+      _impl(new Impl()) {}
+
+connector::LocalZmqTransport::~LocalZmqTransport() {
+    close();
+    delete _impl;
+    _impl = nullptr;
+}
+
+void connector::LocalZmqTransport::open() {
+    if (_is_open)
+        return;
+
+#if defined(LBR_HAS_ZEROMQ) && LBR_HAS_ZEROMQ
+    _impl->context = ::zmq_ctx_new();
+    if (_impl->context == nullptr)
+        throw std::runtime_error("Failed to create ZeroMQ context.");
+
+    const int socket_type = _mode == LocalZmqMode::Publisher ? ZMQ_PUB : ZMQ_SUB;
+    _impl->socket = ::zmq_socket(_impl->context, socket_type);
+    if (_impl->socket == nullptr) {
+        close();
+        throw std::runtime_error("Failed to create ZeroMQ socket.");
+    }
+
+    if (_mode == LocalZmqMode::Publisher) {
+        if (::zmq_bind(_impl->socket, _endpoint.c_str()) != 0) {
+            close();
+            throw std::runtime_error("Failed to bind ZeroMQ publisher socket.");
+        }
+    } else {
+        if (::zmq_connect(_impl->socket, _endpoint.c_str()) != 0) {
+            close();
+            throw std::runtime_error("Failed to connect ZeroMQ subscriber socket.");
+        }
+        if (::zmq_setsockopt(_impl->socket,
+                             ZMQ_SUBSCRIBE,
+                             _topic.data(),
+                             static_cast<int>(_topic.size())) != 0) {
+            close();
+            throw std::runtime_error("Failed to subscribe ZeroMQ topic.");
+        }
+    }
+
+    _is_open = true;
+#else
+    (void)_endpoint;
+    (void)_topic;
+    throw std::runtime_error("ZeroMQ support is not enabled in this build.");
+#endif
+}
+
+void connector::LocalZmqTransport::close() noexcept {
+#if defined(LBR_HAS_ZEROMQ) && LBR_HAS_ZEROMQ
+    if (_impl != nullptr && _impl->socket != nullptr) {
+        ::zmq_close(_impl->socket);
+        _impl->socket = nullptr;
+    }
+
+    if (_impl != nullptr && _impl->context != nullptr) {
+        ::zmq_ctx_term(_impl->context);
+        _impl->context = nullptr;
+    }
+#endif
+    _is_open = false;
+}
+
+void connector::LocalZmqTransport::ensure_open() const {
+    if (!_is_open)
+        throw std::runtime_error("Local ZeroMQ transport is not open.");
+}
+
+void connector::LocalZmqTransport::send_message(const std::string &payload) {
+    ensure_open();
+
+#if defined(LBR_HAS_ZEROMQ) && LBR_HAS_ZEROMQ
+    if (_mode != LocalZmqMode::Publisher)
+        throw std::runtime_error("Only ZeroMQ publisher can send messages.");
+
+    const int sent_topic =
+        static_cast<int>(::zmq_send(_impl->socket, _topic.data(), _topic.size(), ZMQ_SNDMORE));
+    if (sent_topic < 0)
+        throw std::runtime_error("Failed to send ZeroMQ topic frame.");
+
+    const int sent_payload =
+        static_cast<int>(::zmq_send(_impl->socket, payload.data(), payload.size(), 0));
+    if (sent_payload < 0)
+        throw std::runtime_error("Failed to send ZeroMQ payload frame.");
+#else
+    (void)payload;
+    throw std::runtime_error("ZeroMQ support is not enabled in this build.");
+#endif
+}
+
+bool connector::LocalZmqTransport::receive_message(std::string &payload, std::int32_t timeout_ms) {
+    ensure_open();
+
+#if defined(LBR_HAS_ZEROMQ) && LBR_HAS_ZEROMQ
+    if (_mode != LocalZmqMode::Subscriber)
+        throw std::runtime_error("Only ZeroMQ subscriber can receive messages.");
+
+    if (::zmq_setsockopt(_impl->socket, ZMQ_RCVTIMEO, &timeout_ms, sizeof(timeout_ms)) != 0)
+        throw std::runtime_error("Failed to configure ZeroMQ receive timeout.");
+
+    zmq_msg_t topic_frame;
+    if (::zmq_msg_init(&topic_frame) != 0)
+        throw std::runtime_error("Failed to initialize ZeroMQ topic frame.");
+
+    const int topic_result = ::zmq_msg_recv(&topic_frame, _impl->socket, 0);
+    if (topic_result < 0) {
+        ::zmq_msg_close(&topic_frame);
+        return false;
+    }
+
+    ::zmq_msg_close(&topic_frame);
+
+    zmq_msg_t payload_frame;
+    if (::zmq_msg_init(&payload_frame) != 0)
+        throw std::runtime_error("Failed to initialize ZeroMQ payload frame.");
+
+    const int payload_result = ::zmq_msg_recv(&payload_frame, _impl->socket, 0);
+    if (payload_result < 0) {
+        ::zmq_msg_close(&payload_frame);
+        return false;
+    }
+
+    payload.assign(static_cast<const char *>(::zmq_msg_data(&payload_frame)),
+                   static_cast<std::size_t>(::zmq_msg_size(&payload_frame)));
+    ::zmq_msg_close(&payload_frame);
+    return true;
+#else
+    (void)payload;
+    (void)timeout_ms;
+    throw std::runtime_error("ZeroMQ support is not enabled in this build.");
+#endif
+}

--- a/LoRa/tests/connector_tests.cc
+++ b/LoRa/tests/connector_tests.cc
@@ -8,6 +8,8 @@
 #include <gtest/gtest.h>
 
 #include "connector/local_tcp_transport.h"
+#include "connector/local_udp_transport.h"
+#include "connector/local_zmq_transport.h"
 #include "connector/message.h"
 #include "connector/ndjson_file.h"
 
@@ -30,7 +32,7 @@ TEST(ConnectorTests, MessageRoundTripJson) {
     message.message_type = "telemetry_frame";
     message.sequence = 7;
     message.timestamp_ms = 1234567890;
-    message.source = connector::Source::Sx1262;
+    message.source = "sx1262";
     message.payload = {0x01, 0x02, 0x03, 0x04};
     message.checksum_hex = "AB12";
     message.metadata["frame_type"] = "telemetry";
@@ -42,7 +44,7 @@ TEST(ConnectorTests, MessageRoundTripJson) {
     EXPECT_EQ(parsed.message_type, "telemetry_frame");
     EXPECT_EQ(parsed.sequence, 7u);
     EXPECT_EQ(parsed.timestamp_ms, 1234567890);
-    EXPECT_EQ(parsed.source, connector::Source::Sx1262);
+    EXPECT_EQ(parsed.source, std::string("sx1262"));
     EXPECT_EQ(parsed.payload, message.payload);
     EXPECT_TRUE(parsed.checksum_hex.has_value());
     EXPECT_EQ(*parsed.checksum_hex, "AB12");
@@ -67,20 +69,20 @@ TEST(ConnectorTests, MessageRoundTripWithoutOptionalFields) {
     connector::ConnectorMessage message;
     message.sequence = 12;
     message.timestamp_ms = 333;
-    message.source = connector::Source::Sx127;
+    message.source = "sx127";
     message.payload = {0x10};
 
     const connector::ConnectorMessage parsed = connector::ConnectorMessage::from_json(message.to_json());
     EXPECT_EQ(parsed.sequence, 12u);
     EXPECT_EQ(parsed.timestamp_ms, 333);
-    EXPECT_EQ(parsed.source, connector::Source::Sx127);
+    EXPECT_EQ(parsed.source, std::string("sx127"));
     EXPECT_FALSE(parsed.checksum_hex.has_value());
     EXPECT_TRUE(parsed.metadata.empty());
 }
 
 TEST(ConnectorTests, MessageToJsonRejectsUnsupportedSchemaVersion) {
     connector::ConnectorMessage message;
-    message.schema_version = 2;
+    message.schema_version = 0;
     message.payload = {0x01};
 
     EXPECT_THROW(static_cast<void>(message.to_json()), std::runtime_error);
@@ -88,7 +90,7 @@ TEST(ConnectorTests, MessageToJsonRejectsUnsupportedSchemaVersion) {
 
 TEST(ConnectorTests, MessageToJsonRejectsUnsupportedMessageType) {
     connector::ConnectorMessage message;
-    message.message_type = "status";
+    message.message_type.clear();
     message.payload = {0x01};
 
     EXPECT_THROW(static_cast<void>(message.to_json()), std::runtime_error);
@@ -108,9 +110,30 @@ TEST(ConnectorTests, MessageFromJsonRejectsInvalidBase64) {
                  std::runtime_error);
 }
 
-TEST(ConnectorTests, MessageFromJsonRejectsUnknownSource) {
+TEST(ConnectorTests, MessageFromJsonAllowsCustomSource) {
+    const std::string custom_source =
+        R"({"schema_version":1,"message_type":"telemetry_frame","sequence":1,"timestamp_ms":1,"source":"vehicle.alpha","payload_b64":"AQ=="})";
+    const connector::ConnectorMessage parsed = connector::ConnectorMessage::from_json(custom_source);
+    EXPECT_EQ(parsed.source, std::string("vehicle.alpha"));
+}
+
+TEST(ConnectorTests, MessageFromJsonRejectsSchemaVersionZero) {
+    const std::string invalid_schema =
+        R"({"schema_version":0,"message_type":"telemetry_frame","sequence":1,"timestamp_ms":1,"source":"simulated","payload_b64":"AQ=="})";
+    EXPECT_THROW(static_cast<void>(connector::ConnectorMessage::from_json(invalid_schema)),
+                 std::runtime_error);
+}
+
+TEST(ConnectorTests, MessageFromJsonRejectsEmptyMessageType) {
+    const std::string invalid_type =
+        R"({"schema_version":1,"message_type":"","sequence":1,"timestamp_ms":1,"source":"simulated","payload_b64":"AQ=="})";
+    EXPECT_THROW(static_cast<void>(connector::ConnectorMessage::from_json(invalid_type)),
+                 std::runtime_error);
+}
+
+TEST(ConnectorTests, MessageFromJsonRejectsEmptySource) {
     const std::string invalid_source =
-        R"({"schema_version":1,"message_type":"telemetry_frame","sequence":1,"timestamp_ms":1,"source":"x","payload_b64":"AQ=="})";
+        R"({"schema_version":1,"message_type":"telemetry_frame","sequence":1,"timestamp_ms":1,"source":"","payload_b64":"AQ=="})";
     EXPECT_THROW(static_cast<void>(connector::ConnectorMessage::from_json(invalid_source)),
                  std::runtime_error);
 }
@@ -168,7 +191,7 @@ TEST(ConnectorTests, MessageRoundTripWithEscapedPayloadMetadataStrings) {
     connector::ConnectorMessage message;
     message.sequence = 88;
     message.timestamp_ms = 777;
-    message.source = connector::Source::Simulated;
+    message.source = "simulated";
     message.payload = {0x00, 0x0A, 0x1F};
     message.metadata["path"] = "C:\\tmp\\file";
     message.metadata["quote"] = "\"quoted\"";
@@ -185,7 +208,7 @@ TEST(ConnectorTests, MessageToJsonEscapesControlCharacters) {
     connector::ConnectorMessage message;
     message.sequence = 1;
     message.timestamp_ms = 2;
-    message.source = connector::Source::Simulated;
+    message.source = "simulated";
     message.payload = {0x01};
     message.metadata["ctrl"] = std::string("a") + '\b' + '\f' + '\n' + '\r' + '\t' + '"' + '\\' + static_cast<char>(0x01);
 
@@ -208,6 +231,23 @@ TEST(ConnectorTests, MessageFromJsonAcceptsWhitespaceInBase64Payload) {
     EXPECT_EQ(parsed.payload[0], 0x01);
 }
 
+TEST(ConnectorTests, MessageRoundTripCustomProtocolEnvelope) {
+    connector::ConnectorMessage message;
+    message.schema_version = 3;
+    message.message_type = "telemetry_decoded";
+    message.sequence = 999;
+    message.timestamp_ms = 123;
+    message.source = "decoder.flight-v2";
+    message.payload = {0x41, 0x42};
+    message.metadata["protocol"] = "lbr.flight.v2";
+
+    const connector::ConnectorMessage parsed = connector::ConnectorMessage::from_json(message.to_json());
+    EXPECT_EQ(parsed.schema_version, 3);
+    EXPECT_EQ(parsed.message_type, std::string("telemetry_decoded"));
+    EXPECT_EQ(parsed.source, std::string("decoder.flight-v2"));
+    EXPECT_EQ(parsed.metadata.at("protocol"), std::string("lbr.flight.v2"));
+}
+
 TEST(ConnectorTests, NdjsonFileRoundTrip) {
     const std::filesystem::path file_path = temp_file_path("lbr_connector_roundtrip.ndjson");
     std::filesystem::remove(file_path);
@@ -215,7 +255,7 @@ TEST(ConnectorTests, NdjsonFileRoundTrip) {
     connector::ConnectorMessage message;
     message.sequence = 99;
     message.timestamp_ms = 1111;
-    message.source = connector::Source::Simulated;
+    message.source = "simulated";
     message.payload = {0xAA, 0xBB, 0xCC};
 
     {
@@ -229,7 +269,7 @@ TEST(ConnectorTests, NdjsonFileRoundTrip) {
         EXPECT_TRUE(reader.read_next(parsed));
         EXPECT_EQ(parsed.sequence, 99u);
         EXPECT_EQ(parsed.timestamp_ms, 1111);
-        EXPECT_EQ(parsed.source, connector::Source::Simulated);
+        EXPECT_EQ(parsed.source, std::string("simulated"));
         EXPECT_EQ(parsed.payload, message.payload);
     }
 
@@ -309,7 +349,7 @@ TEST(ConnectorTests, LocalTcpTransportExchange) {
                                      "telemetry_frame",
                                      1,
                                      42,
-                                     connector::Source::Simulated,
+                                     "simulated",
                                      {0x11, 0x22},
                                      std::nullopt,
                                      {}}.to_json();
@@ -433,4 +473,113 @@ TEST(ConnectorTests, LocalTcpTransportSupportsEmptyHostAlias) {
 
     server_thread.join();
     EXPECT_EQ(received, "");
+}
+
+TEST(ConnectorTests, LocalUdpTransportExchange) {
+    constexpr std::uint16_t port = 45690;
+    const std::string payload =
+        connector::ConnectorMessage{1,
+                                    "telemetry_frame",
+                                    22,
+                                    123,
+                                    "simulated",
+                                    {0xDE, 0xAD, 0xBE, 0xEF},
+                                    std::nullopt,
+                                    {}}.to_json();
+
+    std::string received;
+
+    std::thread server_thread([&received, port]() {
+        connector::LocalUdpTransport server(connector::LocalUdpMode::Server, "127.0.0.1", port);
+        server.open();
+        ASSERT_TRUE(server.read_datagram(received, 2000));
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    connector::LocalUdpTransport client(connector::LocalUdpMode::Client, "127.0.0.1", port);
+    client.open();
+    client.write_datagram(payload);
+
+    server_thread.join();
+
+    ASSERT_FALSE(received.empty());
+    EXPECT_EQ(connector::ConnectorMessage::from_json(received).sequence, 22u);
+}
+
+TEST(ConnectorTests, LocalUdpTransportReadTimesOutWithoutBlocking) {
+    constexpr std::uint16_t port = 45691;
+
+    connector::LocalUdpTransport server(connector::LocalUdpMode::Server, "127.0.0.1", port);
+    server.open();
+
+    std::string payload;
+    const auto start = std::chrono::steady_clock::now();
+    const bool has_data = server.read_datagram(payload, 100);
+    const auto elapsed_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
+                                                               start)
+            .count();
+
+    EXPECT_FALSE(has_data);
+    EXPECT_TRUE(payload.empty());
+    EXPECT_GE(elapsed_ms, 50);
+    EXPECT_LT(elapsed_ms, 1000);
+}
+
+TEST(ConnectorTests, LocalUdpTransportWriteBeforeOpenThrows) {
+    connector::LocalUdpTransport transport(connector::LocalUdpMode::Client, "127.0.0.1", 45692);
+    EXPECT_THROW(transport.write_datagram("hello"), std::runtime_error);
+}
+
+TEST(ConnectorTests, LocalUdpTransportReadBeforeOpenThrows) {
+    connector::LocalUdpTransport transport(connector::LocalUdpMode::Client, "127.0.0.1", 45693);
+    std::string payload;
+    EXPECT_THROW(static_cast<void>(transport.read_datagram(payload, 5)), std::runtime_error);
+}
+
+TEST(ConnectorTests, LocalUdpTransportServerCannotSendBeforeLearningPeer) {
+    connector::LocalUdpTransport server(connector::LocalUdpMode::Server, "127.0.0.1", 45694);
+    server.open();
+    EXPECT_THROW(server.write_datagram("payload"), std::runtime_error);
+}
+
+TEST(ConnectorTests, LocalZmqTransportThrowsWhenNotBuiltWithZmq) {
+#if defined(LBR_HAS_ZEROMQ) && LBR_HAS_ZEROMQ
+    SUCCEED();
+#else
+    connector::LocalZmqTransport publisher(connector::LocalZmqMode::Publisher,
+                                           "tcp://127.0.0.1:5560",
+                                           "telemetry");
+    EXPECT_THROW(static_cast<void>(publisher.open()), std::runtime_error);
+#endif
+}
+
+TEST(ConnectorTests, LocalZmqTransportPubSubExchange) {
+#if defined(LBR_HAS_ZEROMQ) && LBR_HAS_ZEROMQ
+    constexpr const char *endpoint = "tcp://127.0.0.1:5561";
+    constexpr const char *topic = "telemetry";
+    std::string received;
+
+    std::thread subscriber_thread([&received]() {
+        connector::LocalZmqTransport subscriber(connector::LocalZmqMode::Subscriber,
+                                                endpoint,
+                                                topic);
+        subscriber.open();
+        ASSERT_TRUE(subscriber.receive_message(received, 3000));
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    connector::LocalZmqTransport publisher(connector::LocalZmqMode::Publisher,
+                                           endpoint,
+                                           topic);
+    publisher.open();
+    publisher.send_message("payload-via-zmq");
+
+    subscriber_thread.join();
+    EXPECT_EQ(received, "payload-via-zmq");
+#else
+    GTEST_SKIP() << "ZeroMQ not enabled in this build.";
+#endif
 }

--- a/README.md
+++ b/README.md
@@ -1,40 +1,138 @@
-# LBR-26-Ground-Software
+# LoRa Ground Software
 
-Ground software scaffold for the Long Beach Rocketry SDR station.
+Ground software skeleton for the Long Beach Rocketry station, organized under the LoRa root.
 
-Core implementation now lives under `LoRa/`.
+## What This Update Adds
 
-## Documentation
+- A hardware abstraction interface: `periph::ILoRaModule`
+- Two interchangeable backend skeletons:
+  - `periph::SX1262Module`
+  - `periph::SX127Module`
+- `SDRPipeline` now depends on the LoRa abstraction instead of concrete hardware
+- CLI/config support to choose LoRa module at runtime (`sx1262` or `sx127`)
 
-- Overview: `docs/README.md`
-- Build and run: `docs/build-and-run.md`
-- Configuration format: `docs/configuration.md`
-- Architecture: `docs/architecture.md`
-- Tests and coverage: `docs/build-and-run.md`
-- LoRa module details: `LoRa/README.md`
+## Why The Abstraction Helps
 
-## CI/CD
+The pipeline now consumes telemetry through `ILoRaModule`:
 
-GitHub Actions workflow:
-- `.github/workflows/ci.yml`
+- `init()`
+- `transmit(uint8_t* buf, size_t len)`
+- `receive(uint8_t* buf)`
 
-It runs:
-- build + tests (`ctest`) on pushes and pull requests
-- coverage generation (`gcovr`) with artifacts:
-  - `coverage.xml`
-  - `coverage.html`
+Because `SDRPipeline` only sees this interface, switching from SX126x to SX127x does not require pipeline logic changes. The only change is module selection in config/CLI.
 
-## Quick Start
+## Folder Layout
 
-```powershell
-$env:PATH = "C:\msys64\ucrt64\bin;C:\msys64\usr\bin;$env:PATH"
-cmake -S . -B build -G Ninja -DCMAKE_MAKE_PROGRAM=C:\msys64\ucrt64\bin\ninja.exe -DCMAKE_CXX_COMPILER=C:\msys64\ucrt64\bin\g++.exe -DCMAKE_BUILD_TYPE=Release
-cmake --build build -j
-.\build\lbr_ground.exe -c .\config.demo.yaml -v
+```text
+LoRa/
+  include/
+    cli/
+      args.h
+      config.h
+    periph/
+      i_lora_module.h
+      sx1262_module.h
+      sx127_module.h
+    sdr_pipeline.h
+  src/
+    cli/
+      args.cc
+      config.cc
+    periph/
+      sx1262_module.cc
+      sx127_module.cc
+    main.cc
+    sdr_pipeline.cc
+  tests/
+    args_tests.cc
+    config_tests.cc
+    pipeline_tests.cc
+  config.demo.yaml
+  CMakeLists.txt
 ```
 
-For the current layout, prefer:
+## Module Selection
+
+Choose LoRa backend with either:
+
+- CLI: `--lora-module sx1262` or `--lora-module sx127`
+- YAML:
+
+```yaml
+lora:
+  module: "sx1262"
+```
+
+The CLI option overrides defaults and is validated.
+
+## Build And Run
+
+From repository root:
 
 ```powershell
-.\build\LoRa\lbr_ground.exe -c .\LoRa\config.demo.yaml -v
+cmake -S . -B build
+cmake --build build
+ctest --test-dir build --output-on-failure
 ```
+
+Run app:
+
+```powershell
+.\build\lbr_ground.exe --help
+.\build\lbr_ground.exe -c .\LoRa\config.demo.yaml -v
+.\build\lbr_ground.exe --lora-module sx127 -v
+```
+
+## Coverage
+
+Current score (last run):
+
+- Project source aggregate: line 86.65%, functions 100.00%, branches 53.13%
+
+Project source metrics (all production .cc files):
+
+| File | Line | Functions | Branches |
+| --- | ---: | ---: | ---: |
+| args.cc | 90.91% | 100.00% | 78.57% |
+| config.cc | 100.00% | 100.00% | 65.13% |
+| message.cc | 78.98% | 100.00% | 46.05% |
+| ndjson_file.cc | 93.75% | 100.00% | 53.85% |
+| local_tcp_transport.cc | 78.72% | 100.00% | 42.45% |
+| sx1262_module.cc | 100.00% | 100.00% | 0.00% |
+| sx127_module.cc | 100.00% | 100.00% | 0.00% |
+| sdr_pipeline.cc | 100.00% | 100.00% | 71.43% |
+| main.cc | 89.47% | 100.00% | 43.33% |
+| Project aggregate | 86.65% | 100.00% | 53.13% |
+
+Generate coverage from repository root:
+
+```powershell
+cmake --build build-coverage --target coverage
+```
+
+Coverage artifacts are written to:
+
+- [build-coverage/coverage](../build-coverage/coverage)
+
+Main project source reports are available in:
+
+- [build-coverage/coverage/args.cc.gcov](../build-coverage/coverage/args.cc.gcov)
+- [build-coverage/coverage/config.cc.gcov](../build-coverage/coverage/config.cc.gcov)
+- [build-coverage/coverage/sdr_pipeline.cc.gcov](../build-coverage/coverage/sdr_pipeline.cc.gcov)
+- [build-coverage/coverage/main.cc.gcov](../build-coverage/coverage/main.cc.gcov)
+
+## Current Backend State
+
+`SX1262Module` and `SX127Module` are intentionally skeletal backends. They compile and integrate with the pipeline contract but still need hardware-specific SPI/GPIO/radio register logic for production telemetry.
+
+## Connector
+
+The connector contract used between the LoRa side and the consumer side is documented in [docs/connector.md](docs/connector.md).
+
+The implementation lives under [include/connector](include/connector) and [src/connector](src/connector).
+
+Short version:
+
+- Preferred transport: local socket for live data exchange.
+- Fallback transport: file-based replay for offline testing and debugging.
+- The transport layer is intentionally separate from the LoRa module abstraction so the other team can implement it without changing the pipeline contract.


### PR DESCRIPTION
## Summary
- Implements: feat(connector): add optional ZeroMQ PUB/SUB transport
- Branch: pr/c4eac5f-feat-connector-add-optional-zeromq-pub-s
- Commit: c4eac5f

## Scope
- This PR contains a single stacked commit from lf-test-ci.
- No unrelated changes are included.

## Validation
- Validation status follows the commit's original test/build checks in the stack workflow.

## Notes
- This PR is part of a sequenced series and is intentionally focused.
